### PR TITLE
Better Stringer Decryptors + Major Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Official transformers are linked via the `Transformers` class.
 | Stringer.INVOKEDYNAMIC | stringer.InvokedynamicTransformer | Decrypts invokedynamic obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.REFLECTION_OBFUSCATION | stringer.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.HIDEACCESS_OBFUSCATION | stringer.HideAccessObfuscationTransformer | Decrypts hide access by Stringer (Included invokedynamic and reflection) |
+| Stringer.RESOURCE_ENCRYPTION | stringer.ResourceEncryptionTransformer | Decrypts encrypted resources by Stringer |
 | Zelix.STRING_ENCRYPTION | zelix.StringEncryptionTransformer | Decrypts strings encrypted by Zelix |
 | Zelix.REFLECTION_OBFUSCATION | zelix.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Zelix |
 | Zelix.FLOW_OBFUSCATION | zelix.FlowObfuscationTransformer | Removes flow obfuscation by Zelix |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Official transformers are linked via the `Transformers` class.
 | Allatori.STRING_ENCRYPTION | allatori.StringEncryptionTransformer | Decrypts strings encrypted by Allatori |
 | DashO.STRING_ENCRYPTION | dasho.StringEncryptionTransformer | Decrypts strings encrypted by DashO |
 | SkidSuite.STRING_ENCRYPTION | skidsuite2.StringEncryptionTransformer | Decrypts strings encrypted by SkidSuite2 |
+| SkidSuite.FAKE_EXCEPTION | skidsuite2.FakeExceptionTransformer | Remove fake exceptions by SkidSuite2 |
 | Stringer.STRING_ENCRYPTION | stringer.StringEncryptionTransformer | Decrypts strings encrypted by Stringer |
 | Stringer.INVOKEDYNAMIC | stringer.InvokedynamicTransformer | Decrypts invokedynamic obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.REFLECTION_OBFUSCATION | stringer.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Stringer (Below version 3.0.0) |
@@ -105,8 +106,8 @@ The latest build can be downloaded from my [CI Server](https://ci.samczsun.com/j
 [Allatori](http://www.allatori.com/)  
 [DashO](https://www.preemptive.com/products/dasho/overview)  
 [DexGuard](https://www.guardsquare.com/dexguard)  
-[Smoke](https://newtownia.net/smoke)  
-SkidSuite2 (dead, some forks are listed [here](https://github.com/tetratec/SkidSuite2/network/members))  
+[Smoke](https://newtownia.net/smoke)
+SkidSuite2 (dead, some forks are listed [here](https://github.com/tetratec/SkidSuite2/network/members))
 Generic obfuscation
 
 ## FAQs

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ Official transformers are linked via the `Transformers` class.
 | Stringer.INVOKEDYNAMIC | stringer.InvokedynamicTransformer | Decrypts invokedynamic obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.REFLECTION_OBFUSCATION | stringer.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.HIDEACCESS_OBFUSCATION | stringer.HideAccessObfuscationTransformer | Decrypts hide access by Stringer (Included invokedynamic and reflection) |
+| Stringer.RESOURCE_ENCRYPTION | stringer.ResourceEncryptionTransformer | Decrypts encrypted resources by Stringer |
 | Zelix.STRING_ENCRYPTION | zelix.StringEncryptionTransformer | Decrypts strings encrypted by Zelix |
 | Zelix.REFLECTION_OBFUSCATION | zelix.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Zelix |
 | Zelix.FLOW_OBFUSCATION | zelix.FlowObfuscationTransformer | Removes flow obfuscation by Zelix |

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ Official transformers are linked via the `Transformers` class.
 | Allatori.STRING_ENCRYPTION | allatori.StringEncryptionTransformer | Decrypts strings encrypted by Allatori |
 | DashO.STRING_ENCRYPTION | dasho.StringEncryptionTransformer | Decrypts strings encrypted by DashO |
 | SkidSuite.STRING_ENCRYPTION | skidsuite2.StringEncryptionTransformer | Decrypts strings encrypted by SkidSuite2 |
+| SkidSuite.FAKE_EXCEPTION | skidsuite2.FakeExceptionTransformer | Remove fake exceptions by SkidSuite2 |
 | Stringer.STRING_ENCRYPTION | stringer.StringEncryptionTransformer | Decrypts strings encrypted by Stringer |
 | Stringer.INVOKEDYNAMIC | stringer.InvokedynamicTransformer | Decrypts invokedynamic obfuscated calls by Stringer (Below version 3.0.0) |
 | Stringer.REFLECTION_OBFUSCATION | stringer.ReflectionObfuscationTransformer | Decrypts reflection obfuscated calls by Stringer (Below version 3.0.0) |
@@ -105,8 +106,8 @@ The latest build can be downloaded from my [CI Server](https://ci.samczsun.com/j
 [Allatori](http://www.allatori.com/)  
 [DashO](https://www.preemptive.com/products/dasho/overview)  
 [DexGuard](https://www.guardsquare.com/dexguard)  
-[Smoke](https://newtownia.net/smoke)  
-SkidSuite2 (dead, some forks are listed [here](https://github.com/tetratec/SkidSuite2/network/members))  
+[Smoke](https://newtownia.net/smoke)
+SkidSuite2 (dead, some forks are listed [here](https://github.com/tetratec/SkidSuite2/network/members))
 Generic obfuscation
 
 ## FAQs

--- a/src/main/java/com/javadeobfuscator/deobfuscator/Deobfuscator.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/Deobfuscator.java
@@ -279,7 +279,7 @@ public class Deobfuscator {
 
     public boolean runFromConfig(TransformerConfig config) throws Throwable {
         Transformer transformer = config.getImplementation().newInstance();
-        transformer.init(this, config, classes, classpath);
+        transformer.init(this, config, classes, classpath, inputPassthrough);
         return transformer.transform();
     }
 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
@@ -6,217 +6,599 @@ import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InvokeDynamicInsnNode;
+import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.MultiANewArrayInsnNode;
+
 import com.javadeobfuscator.deobfuscator.utils.Utils;
 
 /**
- * This class is used to retrieve where a method's args begin/end.
+ * This class is used to retrieve where a method's args begin.
  * Somtimes, obfuscators don't like to put a method's args right before its method that uses it.
- * This analyzer can only run backwards, because running forwards doesn't work.
+ * This analyzer can run both forwards and backwards.
  * @author ThisTestUser
  */
 public class ArgsAnalyzer
 {
-	private final MethodNode method;
-
 	/**
-	 * Which index do we start at?
+	 * Which instruction do we start at?
 	 */
-	private final int startIndex;
+	private final AbstractInsnNode start;
 	
 	/**
-	 * How many arguments do we need?
+	 * What direction should we run?
 	 */
 	private final int argSize;
 	
-	public ArgsAnalyzer(MethodNode method, int startIndex, int argSize)
+	/**
+	 * What direction should we run?
+	 */
+	private final Mode mode;
+	
+	/**
+	 * Are there any opcodes which we should immedately stop execution if we pass through them?
+	 */
+	private final int[] stopCodes;
+	
+	public ArgsAnalyzer(AbstractInsnNode start, int argSize, Mode mode, int... stopCodes)
 	{
-		this.method = method;
-		this.startIndex = startIndex;
+		this.start = start;
 		this.argSize = argSize;
+		this.mode = mode;
+		this.stopCodes = stopCodes;
+	}
+	
+	public Result lookupArgs()
+	{
+		if(mode == Mode.BACKWARDS)
+			return lookupArgsBackwards();
+		else if(mode == Mode.FORWARDS)
+			return lookupArgsForwards();
+		else
+			throw new IllegalArgumentException("Unknown mode");
 	}
 	
 	/**
-	 * Performs an arg lookup.
-	 * @return The list of nodes as the arguments, in order.
+	 * Performs an arg lookup backwards.
+	 * @return The first insn node where the argSize is 0.
 	 */
-	public List<AbstractInsnNode> lookupArgs()
+	private Result lookupArgsBackwards()
 	{
-		//Reverse bytecode analysis
-		List<AbstractInsnNode> stack = new ArrayList<>();
-		int neededNodes = 0;
-		//This isn't complete, fix as new errors come
-		for(int i = startIndex; i >= 0; i--)
+		AbstractInsnNode result = null;
+    	int diff = 0;
+		int needed = argSize;
+		AbstractInsnNode ain = start;
+		if(needed == 0)
+			return new Result(0, ain, null);
+		while(ain != null)
+    	{
+			for(int code : stopCodes)
+				if(ain.getOpcode() == code)
+					return null;
+    		int prevNeeded = needed;
+    		if((ain.getOpcode() >= Opcodes.ACONST_NULL && ain.getOpcode() <= Opcodes.ICONST_5)
+    			|| (ain.getOpcode() >= Opcodes.FCONST_0 && ain.getOpcode() <= Opcodes.FCONST_2)
+    			|| ain.getOpcode() == Opcodes.BIPUSH || ain.getOpcode() == Opcodes.SIPUSH)
+    			needed--;
+    		else if((ain.getOpcode() >= Opcodes.LCONST_0 && ain.getOpcode() <= Opcodes.LCONST_1)
+    			|| (ain.getOpcode() >= Opcodes.DCONST_0 && ain.getOpcode() <= Opcodes.DCONST_1))
+    			needed -= 2;
+    		else if(ain.getOpcode() == Opcodes.LDC)
+    		{
+    			LdcInsnNode cst = (LdcInsnNode)ain;
+    			if(cst.cst instanceof Double || cst.cst instanceof Long)
+    				needed -= 2;
+    			else 
+    				needed--;
+    		}else if(ain.getOpcode() == Opcodes.ILOAD || ain.getOpcode() == Opcodes.ALOAD
+    			|| ain.getOpcode() == Opcodes.FLOAD)
+    			needed--;
+    		else if(ain.getOpcode() == Opcodes.DLOAD || ain.getOpcode() == Opcodes.LLOAD)
+    			needed -= 2;
+    		else if(ain.getOpcode() == Opcodes.ISTORE || ain.getOpcode() == Opcodes.FSTORE
+    			|| ain.getOpcode() == Opcodes.ASTORE)
+    			needed++;
+    		else if(ain.getOpcode() == Opcodes.DSTORE || ain.getOpcode() == Opcodes.LSTORE)
+    			needed += 2;
+    		else if(ain.getOpcode() == Opcodes.IALOAD || ain.getOpcode() == Opcodes.FALOAD
+    			|| ain.getOpcode() == Opcodes.AALOAD || ain.getOpcode() == Opcodes.BALOAD
+    			|| ain.getOpcode() == Opcodes.CALOAD || ain.getOpcode() == Opcodes.SALOAD)
+    		{
+    			needed--;
+    			needed += 2;
+    		}else if(ain.getOpcode() == Opcodes.LALOAD || ain.getOpcode() == Opcodes.DALOAD)
+    		{
+    			needed += 2;
+    			needed -= 2;
+    		}else if(ain.getOpcode() == Opcodes.IASTORE || ain.getOpcode() == Opcodes.FASTORE
+    			|| ain.getOpcode() == Opcodes.AASTORE || ain.getOpcode() == Opcodes.BASTORE
+    			|| ain.getOpcode() == Opcodes.CASTORE || ain.getOpcode() == Opcodes.SASTORE)
+    			needed += 3;
+    		else if(ain.getOpcode() == Opcodes.LASTORE || ain.getOpcode() == Opcodes.DASTORE)
+    			needed += 4;
+    		else if(ain.getOpcode() == Opcodes.POP)
+    			needed++;
+    		else if(ain.getOpcode() == Opcodes.POP2)
+    			needed += 2;
+    		else if(ain.getOpcode() == Opcodes.DUP || ain.getOpcode() == Opcodes.DUP_X1 || ain.getOpcode() == Opcodes.DUP_X2)
+    			needed--;
+    		else if(ain.getOpcode() == Opcodes.DUP2 || ain.getOpcode() == Opcodes.DUP2_X1 || ain.getOpcode() == Opcodes.DUP2_X2)
+    			needed -= 2;
+    		else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
+    			|| ain.getOpcode() == Opcodes.IMUL || ain.getOpcode() == Opcodes.IDIV
+    			|| ain.getOpcode() == Opcodes.IREM || ain.getOpcode() == Opcodes.ISHL
+    			|| ain.getOpcode() == Opcodes.ISHR || ain.getOpcode() == Opcodes.IUSHR
+    			|| ain.getOpcode() == Opcodes.IAND || ain.getOpcode() == Opcodes.IOR
+    			|| ain.getOpcode() == Opcodes.IXOR)
+    		{
+    			needed--;
+    			needed += 2;
+    		}else if(ain.getOpcode() == Opcodes.LADD || ain.getOpcode() == Opcodes.LSUB
+    			|| ain.getOpcode() == Opcodes.LMUL || ain.getOpcode() == Opcodes.LDIV
+    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LSHL
+    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR
+    			|| ain.getOpcode() == Opcodes.LAND || ain.getOpcode() == Opcodes.LOR
+    			|| ain.getOpcode() == Opcodes.LXOR)
+    		{
+    			needed -= 2;
+    			needed += 4;
+    		}else if(ain.getOpcode() == Opcodes.FADD || ain.getOpcode() == Opcodes.FSUB
+    			|| ain.getOpcode() == Opcodes.FMUL || ain.getOpcode() == Opcodes.FDIV
+    			|| ain.getOpcode() == Opcodes.FREM || ain.getOpcode() == Opcodes.FCMPL
+    			|| ain.getOpcode() == Opcodes.FCMPG)
+    		{
+    			needed--;
+    			needed += 2;
+    		}else if(ain.getOpcode() == Opcodes.DADD || ain.getOpcode() == Opcodes.DSUB
+    			|| ain.getOpcode() == Opcodes.DMUL || ain.getOpcode() == Opcodes.DDIV
+    			|| ain.getOpcode() == Opcodes.DREM)
+    		{
+    			needed -= 2;
+    			needed += 4;
+    		}else if(ain.getOpcode() == Opcodes.LCMP || ain.getOpcode() == Opcodes.DCMPL
+    			|| ain.getOpcode() == Opcodes.DCMPG)
+    		{
+    			needed--;
+    			needed += 4;
+    		}else if(ain.getOpcode() == Opcodes.I2L || ain.getOpcode() == Opcodes.I2D
+    			|| ain.getOpcode() == Opcodes.F2L || ain.getOpcode() == Opcodes.F2D)
+    			needed--;
+    		else if(ain.getOpcode() == Opcodes.L2I || ain.getOpcode() == Opcodes.D2I
+    			|| ain.getOpcode() == Opcodes.L2F || ain.getOpcode() == Opcodes.D2F)
+    			needed++;
+    		else if(ain.getOpcode() == Opcodes.NEW)
+    			needed--;
+    		else if(ain.getOpcode() == Opcodes.GETSTATIC || ain.getOpcode() == Opcodes.GETFIELD)
+    		{
+    			if(Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.LONG)
+    				needed -= 2;
+    			else
+    				needed--;
+    			if(ain.getOpcode() == Opcodes.GETFIELD)
+    				needed++;
+    		}else if(ain.getOpcode() == Opcodes.PUTSTATIC || ain.getOpcode() == Opcodes.PUTFIELD)
+    		{
+    			if(Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.LONG)
+    				needed += 2;
+    			else
+    				needed++;
+    			if(ain.getOpcode() == Opcodes.PUTFIELD)
+    				needed++;
+    		}else if(ain.getOpcode() == Opcodes.INVOKEVIRTUAL || ain.getOpcode() == Opcodes.INVOKESPECIAL
+    			|| ain.getOpcode() == Opcodes.INVOKEINTERFACE || ain.getOpcode() == Opcodes.INVOKESTATIC)
+    		{
+    			if(Type.getReturnType(((MethodInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getReturnType(((MethodInsnNode)ain).desc).getSort() == Type.LONG)
+    				needed -= 2;
+    			else if(Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.VOID
+    				&& Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.METHOD)
+    				needed--;
+    			if(ain.getOpcode() != Opcodes.INVOKESTATIC)
+    				needed++;
+    			for(Type t : Type.getArgumentTypes(((MethodInsnNode)ain).desc)) 
+    			{
+                     if(t.getSort() == Type.LONG || t.getSort() == Type.DOUBLE)
+                    	 needed += 2;
+                     else
+                    	 needed++;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.INVOKEDYNAMIC)
+    		{
+    			if(Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() == Type.LONG)
+    				needed -= 2;
+    			else if(Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.VOID
+    				&& Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.METHOD)
+    				needed--;
+    			for(Type t : Type.getArgumentTypes(((InvokeDynamicInsnNode)ain).desc)) 
+    			{
+                     if(t.getSort() == Type.LONG || t.getSort() == Type.DOUBLE)
+                    	 needed += 2;
+                     else
+                    	 needed++;
+    			}
+    		}else if((ain.getOpcode() >= Opcodes.IFEQ && ain.getOpcode() <= Opcodes.IFLE)
+    			|| ain.getOpcode() == Opcodes.IFNULL || ain.getOpcode() == Opcodes.IFNONNULL 
+    			|| ain.getOpcode() == Opcodes.TABLESWITCH || ain.getOpcode() == Opcodes.LOOKUPSWITCH 
+    			|| ain.getOpcode() == Opcodes.ATHROW || ain.getOpcode() == Opcodes.RET)
+    			return null;
+    		else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
+    			return null;
+    		else if(ain.getOpcode() == Opcodes.GOTO)
+    			return null;
+    		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
+    			needed += ((MultiANewArrayInsnNode)ain).dims - 1;
+    		else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
+    			|| ain.getOpcode() == Opcodes.ARETURN)
+    			return null;	
+    		else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
+    			return null;	
+    		diff = needed - prevNeeded;
+    		if(needed <= 0)
+    		{
+    			result = ain;
+    			break;
+    		}
+    		ain = Utils.getPrevious(ain);
+    	}
+		return new Result(diff, result, null);
+	}
+	
+	/**
+	 * Performs an arg lookup forwards.
+	 * @return The first insn node where the argSize is 0.
+	 */
+	private Result lookupArgsForwards()
+	{
+		List<AbstractInsnNode> skippedDups = new ArrayList<>();
+		AbstractInsnNode result = null;
+    	int diff = 0;
+		int stackSize = argSize;
+		AbstractInsnNode ain = start;
+		if(stackSize == 0)
+			return new Result(0, ain, skippedDups);
+		while(ain != null)
+    	{
+			for(int code : stopCodes)
+				if(ain.getOpcode() == code)
+					return null;
+    		int prevNeeded = stackSize;
+    		if((ain.getOpcode() >= Opcodes.ACONST_NULL && ain.getOpcode() <= Opcodes.ICONST_5)
+    			|| (ain.getOpcode() >= Opcodes.FCONST_0 && ain.getOpcode() <= Opcodes.FCONST_2)
+    			|| ain.getOpcode() == Opcodes.BIPUSH || ain.getOpcode() == Opcodes.SIPUSH)
+    			stackSize++;
+    		else if((ain.getOpcode() >= Opcodes.LCONST_0 && ain.getOpcode() <= Opcodes.LCONST_1)
+    			|| (ain.getOpcode() >= Opcodes.DCONST_0 && ain.getOpcode() <= Opcodes.DCONST_1))
+    			stackSize += 2;
+    		else if(ain.getOpcode() == Opcodes.LDC)
+    		{
+    			LdcInsnNode cst = (LdcInsnNode)ain;
+    			if(cst.cst instanceof Double || cst.cst instanceof Long)
+    				stackSize += 2;
+    			else 
+    				stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.ILOAD || ain.getOpcode() == Opcodes.ALOAD
+    			|| ain.getOpcode() == Opcodes.FLOAD)
+    			stackSize++;
+    		else if(ain.getOpcode() == Opcodes.DLOAD || ain.getOpcode() == Opcodes.LLOAD)
+    			stackSize += 2;
+    		else if(ain.getOpcode() == Opcodes.ISTORE || ain.getOpcode() == Opcodes.FSTORE
+    			|| ain.getOpcode() == Opcodes.ASTORE)
+    			stackSize--;
+    		else if(ain.getOpcode() == Opcodes.DSTORE || ain.getOpcode() == Opcodes.LSTORE)
+    			stackSize -= 2;
+    		else if(ain.getOpcode() == Opcodes.IALOAD || ain.getOpcode() == Opcodes.FALOAD
+    			|| ain.getOpcode() == Opcodes.AALOAD || ain.getOpcode() == Opcodes.BALOAD
+    			|| ain.getOpcode() == Opcodes.CALOAD || ain.getOpcode() == Opcodes.SALOAD)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.LALOAD || ain.getOpcode() == Opcodes.DALOAD)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.IASTORE || ain.getOpcode() == Opcodes.FASTORE
+    			|| ain.getOpcode() == Opcodes.AASTORE || ain.getOpcode() == Opcodes.BASTORE
+    			|| ain.getOpcode() == Opcodes.CASTORE || ain.getOpcode() == Opcodes.SASTORE)
+    			stackSize -= 3;
+    		else if(ain.getOpcode() == Opcodes.LASTORE || ain.getOpcode() == Opcodes.DASTORE)
+    			stackSize -= 4;
+    		else if(ain.getOpcode() == Opcodes.POP)
+    			stackSize--;
+    		else if(ain.getOpcode() == Opcodes.POP2)
+    			stackSize -= 2;
+    		else if(ain.getOpcode() == Opcodes.DUP)
+    			stackSize++;
+    		else if(ain.getOpcode() == Opcodes.DUP_X1)
+    		{
+    			if(stackSize > 2)
+    				stackSize++;
+    			else
+    				skippedDups.add(ain);
+    		}else if(ain.getOpcode() == Opcodes.DUP_X2)
+    		{
+    			if(stackSize > 3)
+    				stackSize++;
+    			else
+    				skippedDups.add(ain);
+    		}else if(ain.getOpcode() == Opcodes.DUP2)
+    		{
+    			if(stackSize > 2)
+    				stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.DUP2_X1 || ain.getOpcode() == Opcodes.DUP2_X2)
+    			return null;
+    		else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
+    			|| ain.getOpcode() == Opcodes.IMUL || ain.getOpcode() == Opcodes.IDIV
+    			|| ain.getOpcode() == Opcodes.IREM || ain.getOpcode() == Opcodes.ISHL
+    			|| ain.getOpcode() == Opcodes.ISHR || ain.getOpcode() == Opcodes.IUSHR
+    			|| ain.getOpcode() == Opcodes.IAND || ain.getOpcode() == Opcodes.IOR
+    			|| ain.getOpcode() == Opcodes.IXOR)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.LADD || ain.getOpcode() == Opcodes.LSUB
+    			|| ain.getOpcode() == Opcodes.LMUL || ain.getOpcode() == Opcodes.LDIV
+    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LSHL
+    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR
+    			|| ain.getOpcode() == Opcodes.LAND || ain.getOpcode() == Opcodes.LOR
+    			|| ain.getOpcode() == Opcodes.LXOR)
+    		{
+    			stackSize -= 4;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.FADD || ain.getOpcode() == Opcodes.FSUB
+    			|| ain.getOpcode() == Opcodes.FMUL || ain.getOpcode() == Opcodes.FDIV
+    			|| ain.getOpcode() == Opcodes.FREM || ain.getOpcode() == Opcodes.FCMPL
+    			|| ain.getOpcode() == Opcodes.FCMPG)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.DADD || ain.getOpcode() == Opcodes.DSUB
+    			|| ain.getOpcode() == Opcodes.DMUL || ain.getOpcode() == Opcodes.DDIV
+    			|| ain.getOpcode() == Opcodes.DREM)
+    		{
+    			stackSize -= 4;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.LCMP || ain.getOpcode() == Opcodes.DCMPL
+    			|| ain.getOpcode() == Opcodes.DCMPG)
+    		{
+    			stackSize -= 4;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.I2L || ain.getOpcode() == Opcodes.I2D
+    			|| ain.getOpcode() == Opcodes.F2L || ain.getOpcode() == Opcodes.F2D)
+    			stackSize++;
+    		else if(ain.getOpcode() == Opcodes.L2I || ain.getOpcode() == Opcodes.D2I
+    			|| ain.getOpcode() == Opcodes.L2F || ain.getOpcode() == Opcodes.D2F)
+    			stackSize--;
+    		else if(ain.getOpcode() == Opcodes.NEW)
+    			stackSize++;
+    		else if(ain.getOpcode() == Opcodes.GETSTATIC || ain.getOpcode() == Opcodes.GETFIELD)
+    		{
+    			if(ain.getOpcode() == Opcodes.GETFIELD)
+    				stackSize--;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			if(Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.LONG)
+    				stackSize += 2;
+    			else
+    				stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.PUTSTATIC || ain.getOpcode() == Opcodes.PUTFIELD)
+    		{
+    			if(ain.getOpcode() == Opcodes.PUTFIELD)
+    				stackSize--;
+    			if(Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getType(((FieldInsnNode)ain).desc).getSort() == Type.LONG)
+    				stackSize -= 2;
+    			else
+    				stackSize--;
+    		}else if(ain.getOpcode() == Opcodes.INVOKEVIRTUAL || ain.getOpcode() == Opcodes.INVOKESPECIAL
+    			|| ain.getOpcode() == Opcodes.INVOKEINTERFACE || ain.getOpcode() == Opcodes.INVOKESTATIC)
+    		{
+    			if(ain.getOpcode() != Opcodes.INVOKESTATIC)
+    				stackSize--;
+    			for(Type t : Type.getArgumentTypes(((MethodInsnNode)ain).desc)) 
+    			{
+                     if(t.getSort() == Type.LONG || t.getSort() == Type.DOUBLE)
+                    	 stackSize -= 2;
+                     else
+                    	 stackSize--;
+    			}
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			if(Type.getReturnType(((MethodInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getReturnType(((MethodInsnNode)ain).desc).getSort() == Type.LONG)
+    				stackSize += 2;
+    			else if(Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.VOID
+    				&& Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.METHOD)
+    				stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.INVOKEDYNAMIC)
+    		{
+    			for(Type t : Type.getArgumentTypes(((InvokeDynamicInsnNode)ain).desc)) 
+    			{
+                     if(t.getSort() == Type.LONG || t.getSort() == Type.DOUBLE)
+                    	 stackSize -= 2;
+                     else
+                    	 stackSize--;
+    			}
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			if(Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() == Type.DOUBLE
+    				|| Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() == Type.LONG)
+    				stackSize += 2;
+    			else if(Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.VOID
+    				&& Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.METHOD)
+    				stackSize++;
+    		}else if((ain.getOpcode() >= Opcodes.IFEQ && ain.getOpcode() <= Opcodes.IFLE)
+    			|| ain.getOpcode() == Opcodes.IFNULL || ain.getOpcode() == Opcodes.IFNONNULL 
+    			|| ain.getOpcode() == Opcodes.TABLESWITCH || ain.getOpcode() == Opcodes.LOOKUPSWITCH 
+    			|| ain.getOpcode() == Opcodes.ATHROW || ain.getOpcode() == Opcodes.RET)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			return null;
+    		}else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			return null;
+    		}else if(ain.getOpcode() == Opcodes.INSTANCEOF)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.GOTO)
+    			return null;
+    		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
+    			stackSize -= ((MultiANewArrayInsnNode)ain).dims - 1;
+    		else if(ain.getOpcode() == Opcodes.NEWARRAY || ain.getOpcode() == Opcodes.ANEWARRAY
+    			|| ain.getOpcode() == Opcodes.ARRAYLENGTH)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
+    			|| ain.getOpcode() == Opcodes.ARETURN)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+    			{
+    				diff = stackSize - prevNeeded;
+    				result = ain;
+    				break;
+    			}
+    			return null;	
+    		}else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0)
+    			{
+    				diff = stackSize - prevNeeded;
+    				result = ain;
+    				break;
+    			}
+    			return null;	
+    		}
+    		diff = stackSize - prevNeeded;
+    		if(stackSize <= 0)
+    		{
+    			result = ain;
+    			break;
+    		}
+    		ain = Utils.getNext(ain);
+    	}
+		return new Result(diff, result, skippedDups);
+	}
+	
+	public enum Mode
+	{
+		FORWARDS,
+		BACKWARDS;
+	}
+	
+	public static class Result
+	{
+		private final int diff;
+		private final AbstractInsnNode firstArgInsn;
+		private final List<AbstractInsnNode> skippedDups;
+		
+		public Result(int diff, AbstractInsnNode firstArgInsn, List<AbstractInsnNode> skippedDups)
 		{
-			AbstractInsnNode node = method.instructions.get(i);
-			if(Utils.isNumber(node))
-			{
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}else if(node.getOpcode() == Opcodes.ACONST_NULL
-				|| node.getOpcode() == Opcodes.LDC)
-			{
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}else if(node.getOpcode() >= Opcodes.ILOAD
-				&& node.getOpcode() <= Opcodes.ALOAD)
-			{
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}else if(node.getOpcode() >= Opcodes.ISTORE
-				&& node.getOpcode() <= Opcodes.ASTORE)
-				neededNodes++;
-			else if(node.getOpcode() == Opcodes.INVOKEVIRTUAL
-				|| node.getOpcode() == Opcodes.INVOKESPECIAL
-				|| node.getOpcode() == Opcodes.INVOKEINTERFACE)
-			{
-				//Note that we add one for the instance
-				MethodInsnNode cast = (MethodInsnNode)node;
-				neededNodes += Type.getArgumentTypes(cast.desc).length + 1;
-				if(Type.getReturnType(cast.desc).getSort() > 0
-					&& Type.getReturnType(cast.desc).getSort() < 11)
-				{
-					stack.add(0, node);
-					if(neededNodes > 0)
-					{
-						neededNodes--;
-						stack.remove(0);
-					}
-					if(stack.size() >= argSize && neededNodes == 0)
-					{
-						if(stack.size() > argSize)
-							throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-							+ argSize + " !");
-						return stack;
-					}
-				}
-			}else if(node.getOpcode() == Opcodes.INVOKESTATIC)
-			{
-				MethodInsnNode cast = (MethodInsnNode)node;
-				neededNodes += Type.getArgumentTypes(cast.desc).length;
-				if(Type.getReturnType(cast.desc).getSort() > 0
-					&& Type.getReturnType(cast.desc).getSort() < 11)
-				{
-					stack.add(0, node);
-					if(neededNodes > 0)
-					{
-						neededNodes--;
-						stack.remove(0);
-					}
-					if(stack.size() >= argSize && neededNodes == 0)
-					{
-						if(stack.size() > argSize)
-							throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-							+ argSize + " !");
-						return stack;
-					}
-				}
-			}else if(node.getOpcode() == Opcodes.GETSTATIC || node.getOpcode() == Opcodes.GETFIELD)
-			{
-				if(node.getOpcode() == Opcodes.GETFIELD)
-					neededNodes++;
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}else if(node.getOpcode() == Opcodes.PUTFIELD || node.getOpcode() == Opcodes.PUTSTATIC)
-			{
-				if(node.getOpcode() == Opcodes.PUTFIELD)
-					neededNodes++;
-				neededNodes++;
-			}else if(node.getOpcode() == Opcodes.INVOKEDYNAMIC)
-			{
-				//InvokeDynamic adds to the stack
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}else if(node.getOpcode() == Opcodes.NEW)
-			{
-				if(node.getNext() != null 
-					&& node.getNext().getOpcode() == Opcodes.DUP)
-				{
-					stack.add(0, node);
-					if(neededNodes > 0)
-					{
-						neededNodes--;
-						stack.remove(0);
-					}
-					if(stack.size() >= argSize && neededNodes == 0)
-					{
-						if(stack.size() > argSize)
-							throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-							+ argSize + " !");
-						return stack;
-					}
-				}
-				stack.add(0, node);
-				if(neededNodes > 0)
-				{
-					neededNodes--;
-					stack.remove(0);
-				}
-				if(stack.size() >= argSize && neededNodes == 0)
-				{
-					if(stack.size() > argSize)
-						throw new RuntimeException("Recieved an arg size of " + stack.size() + " but expected "
-						+ argSize + " !");
-					return stack;
-				}
-			}
+			this.diff = diff;
+			this.firstArgInsn = firstArgInsn;
+			this.skippedDups = skippedDups;
 		}
-		return null;
+		
+		public int getDiff()
+		{
+			return diff;
+		}
+		
+		public AbstractInsnNode getFirstArgInsn()
+		{
+			return firstArgInsn;
+		}
+		
+		public List<AbstractInsnNode> getSkippedDups()
+		{
+			return skippedDups;
+		}
 	}
 }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/frame/ArgumentFrame.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/frame/ArgumentFrame.java
@@ -17,8 +17,21 @@
 package com.javadeobfuscator.deobfuscator.analyzer.frame;
 
 public class ArgumentFrame extends Frame {
-    public ArgumentFrame() {
+	private int opcode;
+	private int local;
+	
+    public ArgumentFrame(int opcode, int local) {
         super(-1);
+        this.opcode = opcode;
+        this.local = local;
+    }
+    
+    public int getLocal() {
+    	return local;
+    }
+    
+    public int getStoreOpcode() {
+    	return opcode;
     }
     
     // fixme how to determine?

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
@@ -125,7 +125,10 @@ public class MethodExecutor {
                 result = new JavaShort((Short) value);
                 break;
             default:
-            	result = new JavaObject(value, ((JavaArray)arrValue).getValueType(index));
+            	if(value != null && value.getClass().isArray())
+            		result = new JavaArray(value);
+            	else
+            		result = new JavaObject(value, ((JavaArray)arrValue).getValueType(index));
                 break;
         }
         stack.add(0, result);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
@@ -1294,7 +1294,7 @@ public class MethodExecutor {
                         convertArgs(args, Type.getArgumentTypes(cast.desc));
                         args.add(stack.remove(0));
                         if (context.provider.canInvokeMethod(args.get(args.size() - 1).type(), cast.name, cast.desc, args.get(args.size() - 1), args.subList(0, args.size() - 1), context)) {
-                            Object provided = context.provider.invokeMethod(args.get(args.size() - 1).type(), cast.name, cast.desc, args.get(args.size() - 1), args.subList(0, args.size() - 1), context);
+                        	Object provided = context.provider.invokeMethod(args.get(args.size() - 1).type(), cast.name, cast.desc, args.get(args.size() - 1), args.subList(0, args.size() - 1), context);
                             switch (type.getSort()) {
                                 case Type.BOOLEAN:
                                     stack.add(0, new JavaBoolean((Boolean) provided));
@@ -1449,10 +1449,6 @@ public class MethodExecutor {
                                 throw new NoSuchComparisonHandlerException("No comparator found for " + cast.desc);
                             }
                         }
-                        if(Type.getType(cast.desc).getSort() == Type.ARRAY)
-                        	((JavaObject)obj).cast("java/lang/Object");
-                        else
-                        	((JavaObject)obj).cast(cast.desc);
                         break;
                     }
                     case INSTANCEOF: {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/MethodExecutor.java
@@ -341,7 +341,6 @@ public class MethodExecutor {
         if (DEBUG) {
             System.out.println("Executing " + classNode.name + " " + method.name + method.desc);
         }
-        //TODO: JavaMethod/Constructor fix
         forever:
         while (true) {
             try {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -429,7 +429,7 @@ public class JVMMethodProvider extends MethodProvider {
                 return null;
             });
 
-            put("newInstance([Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(JavaConstructor.class).newInstance(context, args.get(0).as(Object[].class)));
+            put("newInstance([Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(JavaConstructor.class).newInstance(context, args.get(0)));
         }});
         put("java/lang/reflect/Method", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("getName()Ljava/lang/String;", (targetObject, args, context) -> targetObject.as(JavaMethod.class).getName());
@@ -440,7 +440,7 @@ public class JVMMethodProvider extends MethodProvider {
                 return null;
             });
             put("hashCode()I", (targetObject, args, context) -> targetObject.as(JavaMethod.class).hashCode());
-            put("invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(JavaMethod.class).invoke(args.get(0), args.get(1).as(Object[].class)));
+            put("invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(JavaMethod.class).invoke(args.get(0), args.get(1)));
         }});
         put("java/lang/reflect/Field", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("getName()Ljava/lang/String;", (targetObject, args, context) -> targetObject.as(JavaField.class).getName());

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -223,6 +223,7 @@ public class JVMMethodProvider extends MethodProvider {
                 targetObject.initialize(new String(args.get(0).as(byte[].class), args.get(1).as(String.class)));
                 return null;
             });
+            put("toString()Ljava/lang/String;", (targetObject, args, context) -> targetObject.as(String.class).toString());
             put("intern()Ljava/lang/String;", (targetObject, args, context) -> targetObject.as(String.class).intern());
             put("valueOf(I)Ljava/lang/String;", (targetObject, args, context) -> String.valueOf(args.get(0).intValue()));
             put("equals(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.as(String.class).equals(args.get(0).value()));

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -18,6 +18,7 @@ package com.javadeobfuscator.deobfuscator.executor.defined;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
 import java.net.URI;
@@ -69,7 +70,12 @@ public class JVMMethodProvider extends MethodProvider {
                 }
                 return null;
             });
-            put("equals(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.equals(args.get(0).value()));
+            put("equals(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.value().equals(args.get(0).value()));
+            put("clone()Ljava/lang/Object;", (targetObject, args, context) -> {
+            	Method clone = Object.class.getDeclaredMethod("clone");
+            	clone.setAccessible(true);
+            	return clone.invoke(targetObject.value());
+            });
             put("<init>()V", (targetObject, args, context) -> {
                 expect(targetObject, targetObject.type()); 
                 targetObject.initialize(new JavaObject(null, targetObject.type())); 
@@ -149,6 +155,9 @@ public class JVMMethodProvider extends MethodProvider {
         }});
         put("java/util/List", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("add(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.as(List.class).add(args.get(0).as(Object.class)));
+            put("size()I", (targetObject, args, context) -> targetObject.as(List.class).size());
+            put("get(I)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(List.class).get(args.get(0).intValue()));
+            put("set(ILjava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(List.class).set(args.get(0).intValue(), args.get(1).as(Object.class)));
             put("toArray()[Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(List.class).toArray());
             put("iterator()Ljava/util/Iterator;", (targetObject, args, context) -> targetObject.as(List.class).iterator());
         }});
@@ -162,6 +171,17 @@ public class JVMMethodProvider extends MethodProvider {
                 targetObject.initialize(new ArrayList<>());
                 return null;
             });
+            put("<init>(Ljava/util/Collection;)V", (targetObject, args, context) -> {
+                expect(targetObject, "java/util/ArrayList");
+                targetObject.initialize(new ArrayList<>(args.get(0).as(Collection.class)));
+                return null;
+            });
+            put("add(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.as(ArrayList.class).add(args.get(0).as(Object.class)));
+            put("size()I", (targetObject, args, context) -> targetObject.as(ArrayList.class).size());
+            put("get(I)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(ArrayList.class).get(args.get(0).intValue()));
+            put("set(ILjava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(ArrayList.class).set(args.get(0).intValue(), args.get(1).as(Object.class)));
+            put("toArray()[Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(ArrayList.class).toArray());
+            put("iterator()Ljava/util/Iterator;", (targetObject, args, context) -> targetObject.as(ArrayList.class).iterator());
         }});
         put("java/lang/String", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("<init>([CII)V", (targetObject, args, context) -> {
@@ -560,6 +580,7 @@ public class JVMMethodProvider extends MethodProvider {
                 return null;
             });
             put("put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(HashMap.class).put(args.get(0), args.get(1)));
+            put("get(Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(HashMap.class).get(args.get(0).value()));
             put("isEmpty()Z", (targetObject, args, context) -> targetObject.as(HashMap.class).isEmpty()); 
         }});
         put("java/util/HashSet", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -17,6 +17,7 @@
 package com.javadeobfuscator.deobfuscator.executor.defined;
 
 import java.io.*;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
 import java.net.URI;
@@ -27,6 +28,8 @@ import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -116,6 +119,33 @@ public class JVMMethodProvider extends MethodProvider {
                 }
                 return null;
             });
+        }});
+        put("java/io/PushbackInputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
+            put("<init>(Ljava/io/InputStream;I)V", (targetObject, args, context) -> {
+                targetObject.initialize(new PushbackInputStream(args.get(0).as(InputStream.class), args.get(1).intValue()));
+                return null;
+            });
+            put("unread([BII)V", (targetObject, args, context) -> {
+            	targetObject.as(PushbackInputStream.class).unread(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue());
+            	return null;
+            });
+        }});
+        put("java/io/FilterInputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
+            put("<init>(Ljava/io/InputStream;)V", (targetObject, args, context) -> {
+            	Constructor<FilterInputStream> init = FilterInputStream.class.getDeclaredConstructor(InputStream.class);
+            	init.setAccessible(true);
+            	targetObject.initialize(init.newInstance(args.get(0).as(InputStream.class)));
+                return null;
+            });
+        }});
+        put("java/util/zip/InflaterInputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
+        	 put("<init>(Ljava/io/InputStream;Ljava/util/zip/Inflater;)V", (targetObject, args, context) -> {
+                 targetObject.initialize(new InflaterInputStream(args.get(0).as(InputStream.class), args.get(1).as(Inflater.class)));
+                 return null;
+             });
+        }});
+        put("java/io/InputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
+        	put("read([BII)I", (targetObject, args, context) -> targetObject.as(InputStream.class).read(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue()));
         }});
         put("java/util/List", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("add(Ljava/lang/Object;)Z", (targetObject, args, context) -> targetObject.as(List.class).add(args.get(0).as(Object.class)));

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -488,9 +488,7 @@ public class JVMMethodProvider extends MethodProvider {
                 targetObject.initialize(args.get(0).value());
                 return null;
             });
-            put("setTarget(Ljava/lang/invoke/MethodHandle;)V", (targetObject, args, context) -> {
-            	return null;
-            });
+            put("setTarget(Ljava/lang/invoke/MethodHandle;)V", (targetObject, args, context) -> null);
             put("getTarget()Ljava/lang/invoke/MethodHandle;", (targetObject, args, context) -> targetObject.value());
         }});
         put("java/lang/System", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -135,6 +135,7 @@ public class JVMMethodProvider extends MethodProvider {
             	targetObject.as(PushbackInputStream.class).unread(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue());
             	return null;
             });
+            put("read([BII)I", (targetObject, args, context) -> targetObject.as(PushbackInputStream.class).read(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue()));
         }});
         put("java/io/FilterInputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("<init>(Ljava/io/InputStream;)V", (targetObject, args, context) -> {
@@ -143,13 +144,26 @@ public class JVMMethodProvider extends MethodProvider {
             	targetObject.initialize(init.newInstance(args.get(0).as(InputStream.class)));
                 return null;
             });
+            put("read([BII)I", (targetObject, args, context) -> targetObject.as(FilterInputStream.class).read(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue()));
         }});
         put("java/util/zip/InflaterInputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
         	 put("<init>(Ljava/io/InputStream;Ljava/util/zip/Inflater;)V", (targetObject, args, context) -> {
                  targetObject.initialize(new InflaterInputStream(args.get(0).as(InputStream.class), args.get(1).as(Inflater.class)));
                  return null;
              });
+        	 put("read([B)I", (targetObject, args, context) -> targetObject.as(InflaterInputStream.class).read(args.get(0).as(byte[].class)));
+        	 put("read([BII)I", (targetObject, args, context) -> targetObject.as(InflaterInputStream.class).read(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue()));
         }});
+        put("java/util/zip/Inflater", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
+        	put("<init>(Z)V", (targetObject, args, context) -> {
+        		targetObject.initialize(new Inflater(args.get(0).as(boolean.class)));
+        		return null;
+        	});
+        	put("setInput([BII)V", (targetObject, args, context) -> {
+        		targetObject.as(Inflater.class).setInput(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue());
+        		return null;
+        	});
+       }});
         put("java/io/InputStream", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
         	put("read([BII)I", (targetObject, args, context) -> targetObject.as(InputStream.class).read(args.get(0).as(byte[].class), args.get(1).intValue(), args.get(2).intValue()));
         }});

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -631,13 +631,7 @@ public class JVMMethodProvider extends MethodProvider {
         put("java/math/BigInteger", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("<init>(Ljava/lang/String;I)V", (targetObject, args, context) -> {
                 expect(targetObject, "java/math/BigInteger");
-                if (args.get(1).value() instanceof Byte) { // FIXME
-                    targetObject.initialize(new BigInteger(args.get(0).as(String.class), (byte) args.get(1).value()));
-                } else if (args.get(1).value() instanceof Short) {
-                    targetObject.initialize(new BigInteger(args.get(0).as(String.class), (short) args.get(1).value()));
-                } else {
-                    targetObject.initialize(new BigInteger(args.get(0).as(String.class), (int) args.get(1).value()));
-                }
+                targetObject.initialize(new BigInteger(args.get(0).as(String.class), args.get(1).intValue()));
                 return null;
             });
             put("add(Ljava/math/BigInteger;)Ljava/math/BigInteger;", (targetObject, args, context) -> targetObject.as(BigInteger.class).add(args.get(0).as(BigInteger.class)));

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
@@ -1,12 +1,8 @@
 package com.javadeobfuscator.deobfuscator.executor.defined.types;
 
 import com.javadeobfuscator.deobfuscator.executor.Context;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaDouble;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaFloat;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaInteger;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaLong;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaObject;
-import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
+import com.javadeobfuscator.deobfuscator.executor.values.*;
+
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodNode;
 import com.javadeobfuscator.deobfuscator.utils.PrimitiveUtils;
@@ -52,7 +48,15 @@ public class JavaConstructor {
                 Type type = (Type)arg;
                 arg = new JavaClass(type.getInternalName().replace('/', '.'), context);
             }
-            if(arg instanceof Integer)
+    		if(arg instanceof Boolean)
+    			javaArgs.add(0, new JavaBoolean((Boolean)arg));
+    		else if(arg instanceof Character)
+                javaArgs.add(0, new JavaCharacter((Character)arg));
+    		else if(arg instanceof Byte)
+                javaArgs.add(0, new JavaByte((Byte)arg));
+    		else if(arg instanceof Short)
+                javaArgs.add(0, new JavaShort((Short)arg));
+    		else if(arg instanceof Integer)
                 javaArgs.add(0, new JavaInteger((Integer)arg));
             else if(arg instanceof Float)
                 javaArgs.add(0, new JavaFloat((Float)arg));

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
@@ -36,13 +36,16 @@ public class JavaConstructor {
         return params.toArray(new JavaClass[params.size()]);
     }
 
-    public Object newInstance(Context context, Object[] args)
+    public Object newInstance(Context context, Object argsObject)
     {
+    	Object[] args = (Object[])((JavaArray)argsObject).value();
+    	String[] argTypes = ((JavaArray)argsObject).getTypeArray();
     	MethodNode method = clazz.getClassNode().methods.stream().filter(m -> m.name.equals("<init>") 
     		&& m.desc.equals(desc)).findFirst().orElse(null);
     	List<JavaValue> javaArgs = new ArrayList<>();
-    	for(Object arg : args)
+    	for(int i = 0; i < args.length; i++)
     	{
+    		Object arg = args[i];
     		if(arg instanceof Type)
     		{
                 Type type = (Type)arg;
@@ -64,8 +67,10 @@ public class JavaConstructor {
                 javaArgs.add(0, new JavaDouble((Double)arg));
             else if(arg instanceof Long)
                 javaArgs.add(0, new JavaLong((Long)arg));
+            else if(arg != null && arg.getClass().isArray())
+            	javaArgs.add(new JavaArray(arg));
             else
-            	javaArgs.add(JavaValue.valueOf(arg));
+            	javaArgs.add(new JavaObject(arg, argTypes[i]));
     	}
     	JavaObject instance = new JavaObject(clazz.getName().replace(".", "/"));
     	context.provider.invokeMethod(clazz.getName().replace(".", "/"), method.name, method.desc,

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaConstructor.java
@@ -36,10 +36,19 @@ public class JavaConstructor {
         return params.toArray(new JavaClass[params.size()]);
     }
 
-    public Object newInstance(Context context, Object argsObject)
+    public Object newInstance(Context context, JavaValue argsObject)
     {
-    	Object[] args = (Object[])((JavaArray)argsObject).value();
-    	String[] argTypes = ((JavaArray)argsObject).getTypeArray();
+    	Object[] args; 
+    	String[] argTypes;
+    	if(argsObject.value() == null) 
+    	{
+    		args = null;
+    		argTypes = null;
+    	}else
+    	{
+    		args = (Object[])((JavaArray)argsObject).value();
+    		argTypes = ((JavaArray)argsObject).getTypeArray();
+    	}
     	MethodNode method = clazz.getClassNode().methods.stream().filter(m -> m.name.equals("<init>") 
     		&& m.desc.equals(desc)).findFirst().orElse(null);
     	List<JavaValue> javaArgs = new ArrayList<>();

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
@@ -85,6 +85,7 @@ public class JavaMethod {
     public Object invoke(JavaValue instance, Object[] args) {
         try {
         	//Fix for unboxing/boxing
+        	List<Integer> fixed = new ArrayList<>();
             if(args != null && args.length == getParameterTypes().length)
             	for(int i = 0; i < args.length; i++)
             	{
@@ -93,49 +94,53 @@ public class JavaMethod {
             		JavaClass argClass = params[i];
             		if(argClass.isPrimitive())
             		{
-            			Object value;
-            			if(!(o instanceof JavaValue))
-            				value = o;
-            			else
-            				value = ((JavaValue)o).value();
+            			Object value = o;
             			if(Primitives.unwrap(value.getClass()).getName().equals(argClass.getName()))
 	            			switch(argClass.getName())
 	            			{
 	            				case "boolean":
 	            					args[i] = new JavaBoolean((Boolean)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "byte":
 	            					args[i] = new JavaByte((Byte)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "char":
 	            					args[i] = new JavaCharacter((Character)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "double":
 	            					args[i] = new JavaDouble((Double)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "float":
 	            					args[i] = new JavaFloat((Float)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "int":
 	            					args[i] = new JavaInteger((Integer)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "long":
 	            					args[i] = new JavaLong((Long)o);
+	            					fixed.add(i);
 	            					break;
 	            				case "short":
 	            					args[i] = new JavaShort((Short)o);
+	            					fixed.add(i);
 	            					break;
 	            			}
             		}
             	}
             List<JavaValue> argsobjects = new ArrayList<>();
             if (args != null) {
-                for (Object o : args) {
-                	if(!(o instanceof JavaValue))
-                		//Arrays
+                for (int i = 0; i < args.length; i++) {
+                	Object o = args[i];
+                	if(!fixed.contains(i))
                 		argsobjects.add(JavaValue.valueOf(o));
                 	else
-                		argsobjects.add((JavaValue) o);
+                		argsobjects.add((JavaValue)o);
                 }
             }
 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
@@ -82,7 +82,9 @@ public class JavaMethod {
         return getDeclaringClass().getName().hashCode() ^ getName().hashCode();
     }
 
-    public Object invoke(JavaValue instance, Object[] args) {
+    public Object invoke(JavaValue instance, Object argsObject) {
+    	Object[] args = (Object[])((JavaArray)argsObject).value();
+    	String[] argTypes = ((JavaArray)argsObject).getTypeArray();
         try {
         	//Fix for unboxing/boxing
         	List<Integer> fixed = new ArrayList<>();
@@ -138,8 +140,12 @@ public class JavaMethod {
                 for (int i = 0; i < args.length; i++) {
                 	Object o = args[i];
                 	if(!fixed.contains(i))
-                		argsobjects.add(JavaValue.valueOf(o));
-                	else
+                	{
+                		if(o != null && o.getClass().isArray())
+                			argsobjects.add(new JavaArray(o));
+                        else
+                        	argsobjects.add(new JavaObject(o, argTypes[i]));
+                	}else
                 		argsobjects.add((JavaValue)o);
                 }
             }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
@@ -82,9 +82,18 @@ public class JavaMethod {
         return getDeclaringClass().getName().hashCode() ^ getName().hashCode();
     }
 
-    public Object invoke(JavaValue instance, Object argsObject) {
-    	Object[] args = (Object[])((JavaArray)argsObject).value();
-    	String[] argTypes = ((JavaArray)argsObject).getTypeArray();
+    public Object invoke(JavaValue instance, JavaValue argsObject) {
+    	Object[] args; 
+    	String[] argTypes;
+    	if(argsObject.value() == null) 
+    	{
+    		args = null;
+    		argTypes = null;
+    	}else
+    	{
+    		args = (Object[])((JavaArray)argsObject).value();
+    		argTypes = ((JavaArray)argsObject).getTypeArray();
+    	}
         try {
         	//Fix for unboxing/boxing
         	List<Integer> fixed = new ArrayList<>();

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaArray.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaArray.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Sam Sun <me@samczsun.com>
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.javadeobfuscator.deobfuscator.executor.values;
+
+import java.lang.reflect.Array;
+import java.util.AbstractMap;
+import java.util.Map.Entry;
+
+import org.objectweb.asm.Type;
+
+public class JavaArray extends JavaObject {
+    private Object array;
+    private String[] typeArray;
+
+    public JavaArray(Object array) 
+    {
+    	super(array, "java/lang/Object");
+    	if(!array.getClass().isArray())
+    		throw new IllegalArgumentException("Object must be array");
+        this.array = array;
+    	typeArray = new String[Array.getLength(array)];
+    	for(int i = 0; i < Array.getLength(array); i++) 
+    	{
+    		Object o = Array.get(array, i);
+    		if(o == null)
+        		typeArray[i] = "java/lang/Object";
+        	else if(Type.getType(o.getClass()).getSort() == Type.OBJECT)
+        		typeArray[i] = JavaValue.valueOf(o).type();
+    		else if(Type.getType(o.getClass()).getSort() == Type.ARRAY)
+    			typeArray[i] = "java/lang/Object";
+    		else
+    			typeArray[i] = Type.getType(o.getClass()).getClassName();
+    	}
+    }
+    
+    public JavaArray(Object array, String[] typeArray) 
+    {
+    	super(array, "java/lang/Object");
+    	if(!array.getClass().isArray())
+    		throw new IllegalArgumentException("Object must be array");        
+    	this.array = array;
+    	this.typeArray = typeArray;
+    }
+
+    
+    public void onValueStored(int index, String type)
+    {
+    	typeArray[index] = type;
+    }
+    
+    public String getValueType(int index) 
+    {
+		return typeArray[index];
+    }
+    
+    public String[] getTypeArray() 
+    {
+    	return typeArray;
+    }
+     
+    public Entry<Object, String[]> getObjectArrayWithValues() 
+    {
+    	return new AbstractMap.SimpleEntry<>(array, typeArray);
+    }
+    
+    @Override
+    public Object value() {
+        return this.array;
+    }
+
+    @Override
+    public JavaObject copy() {
+        return this;
+    }
+
+    @Override
+    public void initialize(Object value) {
+    	throw new IllegalStateException("Cannot initialize an array twice");
+    }
+    
+    @Override
+    public String toString() {
+        return "JavaArray@" + Integer.toHexString(System.identityHashCode(this)) + "(value=" + array + ")";
+    }
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
@@ -41,10 +41,6 @@ public class JavaObject extends JavaValue {
     public void initialize(Object value) {
         this.value = value;
     }
-    
-    public void cast(String type) {
-        this.type = type;
-    }
 
     public String type() {
         return this.type;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
@@ -41,6 +41,10 @@ public class JavaObject extends JavaValue {
     public void initialize(Object value) {
         this.value = value;
     }
+    
+    public void cast(String type) {
+        this.type = type;
+    }
 
     public String type() {
         return this.type;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaObject.java
@@ -16,9 +16,14 @@
 
 package com.javadeobfuscator.deobfuscator.executor.values;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
 public class JavaObject extends JavaValue {
     private Object value;
     private String type;
+    public static final Map<String, Function<Object, Object>> patchClasses = new HashMap<>();
 
     public JavaObject(Object value, String type) {
         this.value = value;
@@ -39,7 +44,10 @@ public class JavaObject extends JavaValue {
     }
 
     public void initialize(Object value) {
-        this.value = value;
+    	if(patchClasses.containsKey(type))
+    		this.value = patchClasses.get(type).apply(value);
+    	else
+    		this.value = value;
     }
 
     public String type() {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaValue.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/values/JavaValue.java
@@ -16,8 +16,17 @@
 
 package com.javadeobfuscator.deobfuscator.executor.values;
 
+import org.objectweb.asm.Type;
+
 import com.google.common.primitives.Primitives;
 import com.javadeobfuscator.deobfuscator.executor.MethodExecutor;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaClass;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaConstantPool;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaConstructor;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaField;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaMethod;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaMethodHandle;
+import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaThread;
 import com.javadeobfuscator.deobfuscator.executor.exceptions.ExecutionException;
 
 public abstract class JavaValue {
@@ -73,7 +82,28 @@ public abstract class JavaValue {
     }
 
     public static JavaValue valueOf(Object cst) {
-        return new JavaObject(cst, "java/lang/Object"); //fixme type
+    	if(cst == null)
+    		return new JavaObject(cst, "java/lang/Object");
+    	else if(cst.getClass().isArray())
+    		return new JavaObject(cst, "java/lang/Object");
+    	else if(cst instanceof JavaThread)
+    		return new JavaObject(cst, "java/lang/Thread");
+    	else if(cst instanceof JavaMethodHandle)
+    		return new JavaObject(cst, "java/lang/invoke/MethodHandle");
+    	else if(cst instanceof JavaMethod)
+    		return new JavaObject(cst, "java/lang/reflect/Method");
+    	else if(cst instanceof JavaField)
+    		return new JavaObject(cst, "java/lang/reflect/Field");
+    	else if(cst instanceof JavaConstructor)
+    		return new JavaObject(cst, "java/lang/reflect/Constructor");
+    	else if(cst instanceof JavaConstantPool)
+    		return new JavaObject(cst, "sun/reflect/ConstantPool");
+    	else if(cst instanceof JavaClass)
+    		return new JavaObject(cst, "java/lang/Class");
+    	else if(cst instanceof JavaObject)
+    		return new JavaObject(cst, ((JavaObject)cst).type());
+    	else
+    		return new JavaObject(cst, Type.getType(cst.getClass()).getInternalName());
     }
 
     public static JavaValue forPrimitive(Class<?> prim) {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformer.java
@@ -17,27 +17,26 @@
 package com.javadeobfuscator.deobfuscator.transformers;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
-
 import com.javadeobfuscator.deobfuscator.Deobfuscator;
 import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
 import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.MethodNode;
 
 public abstract class Transformer<T extends TransformerConfig> {
 
     protected Map<String, ClassNode> classes;
     protected Map<String, ClassNode> classpath;
+    protected Map<String, byte[]> inputPassthrough = new HashMap<>();
 
     private Deobfuscator deobfuscator;
     private T config;
 
-    public void init(Deobfuscator deobfuscator, TransformerConfig config, Map<String, ClassNode> classes, Map<String, ClassNode> classpath) {
+    public void init(Deobfuscator deobfuscator, TransformerConfig config, Map<String, ClassNode> classes, Map<String, ClassNode> classpath, Map<String, byte[]> inputPassThrough) {
         this.deobfuscator = deobfuscator;
         this.classes = classes;
         this.classpath = classpath;
+        this.inputPassthrough = inputPassThrough;
         this.config = (T) config;
     }
 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
@@ -65,6 +65,7 @@ public class Transformers {
 
     public static class SkidSuite {
         public static final Class<? extends Transformer> STRING_ENCRYPTION = com.javadeobfuscator.deobfuscator.transformers.skidsuite2.StringEncryptionTransformer.class;
+        public static final Class<? extends Transformer> FAKE_EXCEPTION = com.javadeobfuscator.deobfuscator.transformers.skidsuite2.FakeExceptionTransformer.class;
     }
 
     public static class Normalizer {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
@@ -37,6 +37,7 @@ public class Transformers {
         public static final Class<? extends Transformer> INVOKEDYNAMIC = com.javadeobfuscator.deobfuscator.transformers.stringer.InvokedynamicTransformer.class;
         public static final Class<? extends Transformer> REFLECTION_OBFUSCATION = com.javadeobfuscator.deobfuscator.transformers.stringer.ReflectionObfuscationTransformer.class;
         public static final Class<? extends Transformer> HIDEACCESS_OBFUSCATION = com.javadeobfuscator.deobfuscator.transformers.stringer.HideAccessObfuscationTransformer.class;
+        public static final Class<? extends Transformer> RESOURCE_ENCRYPTION = com.javadeobfuscator.deobfuscator.transformers.stringer.ResourceEncryptionTransformer.class;
     }
     
     public static class General {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
@@ -308,7 +308,7 @@ public class ConstantFolder extends Transformer<ConstantFolder.Config> {
                                 Set<AbstractInsnNode> remove = new HashSet<>();
                                 for (Frame frame0 : frames) {
                                     PopFrame frame = (PopFrame) frame0;
-                                    if (frame.getRemoved().get(0) instanceof LdcFrame && (ain.getOpcode() == POP2 ? frame.getRemoved().get(1) instanceof LdcFrame : true)) {
+                                    if (frame.getRemoved().get(0) instanceof LdcFrame && (ain.getOpcode() == POP2 ? frame.getRemoved().size() == 2 && frame.getRemoved().get(1) instanceof LdcFrame : true)) {
                                         for (Frame deletedFrame : frame.getRemoved()) {
                                             if (deletedFrame.getChildren().size() > 1) {
                                                 // ldc -> ldc -> swap -> pop = we can't even

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/FakeExceptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/FakeExceptionTransformer.java
@@ -1,0 +1,55 @@
+package com.javadeobfuscator.deobfuscator.transformers.skidsuite2;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+
+public class FakeExceptionTransformer extends Transformer<TransformerConfig>
+{
+	@Override
+	public boolean transform() throws Throwable
+	{
+		System.out.println("[SkidSuite] [FakeExceptionTransformer] Starting");
+		AtomicInteger counter = new AtomicInteger();
+		classNodes().forEach(classNode -> classNode.methods.stream()
+			.filter(
+				methodNode -> methodNode.instructions.getFirst() != null)
+			.forEach(methodNode -> {
+				List<TryCatchBlockNode> remove = new ArrayList<>();
+				List<AbstractInsnNode> nodesRemove = new ArrayList<>();
+				for(TryCatchBlockNode tc : methodNode.tryCatchBlocks)
+				{
+					if(tc.handler == null || tc.handler.getNext() == null)
+						remove.add(tc);
+					else if(tc.handler.getNext().getOpcode() == Opcodes.ACONST_NULL
+						&& tc.handler.getNext().getNext() != null
+						&& tc.handler.getNext().getNext().getOpcode() == Opcodes.ATHROW)
+					{
+						remove.add(tc);
+						counter.getAndIncrement();
+						LabelNode begin = tc.handler;
+						AbstractInsnNode next = begin;
+						while(!nodesRemove.contains(next) && next != null && (next.getOpcode() != -1 || next == begin))
+						{
+							nodesRemove.add(next);
+							next = next.getNext();
+						}
+					}
+				}
+				for(TryCatchBlockNode toRemove : remove)
+					methodNode.tryCatchBlocks.remove(toRemove);
+				for(AbstractInsnNode ain : nodesRemove)
+					methodNode.instructions.remove(ain);
+				
+			}));
+		System.out.println("[SkidSuite] [FakeExceptionTransformer] Removed "
+			+ counter.get() + " fake try-catch blocks");
+		System.out.println("[SkidSuite] [FakeExceptionTransformer] Done");
+		return true;
+	}
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/StringEncryptionTransformer.java
@@ -92,7 +92,7 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
                             if (newArrayFrame.getLength() instanceof LdcFrame) {
                             	localRemove.add(result.getMapping().get(newArrayFrame.getLength()));
                                 char[] arr = new char[((Number) ((LdcFrame) newArrayFrame.getLength()).getConstant()).intValue()];
-                                JavaObject obj = new JavaObject(arr, "[C");
+                                JavaObject obj = new JavaObject(arr, "java/lang/Object");
                                 for (Frame child0 : arg.getChildren()) {
                                     if (child0 instanceof ArrayStoreFrame) {
                                         ArrayStoreFrame arrayStoreFrame = (ArrayStoreFrame) child0;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/skidsuite2/StringEncryptionTransformer.java
@@ -97,12 +97,6 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
                                     if (child0 instanceof ArrayStoreFrame) {
                                         ArrayStoreFrame arrayStoreFrame = (ArrayStoreFrame) child0;
                                         if (arrayStoreFrame.getIndex() instanceof LdcFrame && arrayStoreFrame.getObject() instanceof LdcFrame) {
-                                        	if(arrayStoreFrame.getIndex().getChildren().get(0) instanceof DupFrame
-                                        		&& ((DupFrame)arrayStoreFrame.getIndex().getChildren().get(0)).getOpcode() == Opcodes.DUP_X2)
-                                        	{
-                                        		localRemove.add(result.getMapping().get(arrayStoreFrame.getIndex().getChildren().get(0)));
-                                        		methodNode.instructions.insertBefore(methodInsnNode, new LdcInsnNode(((LdcFrame) arrayStoreFrame.getIndex()).getConstant()));
-                                        	}
                                         	localRemove.add(result.getMapping().get(arrayStoreFrame.getIndex()));
                                         	localRemove.add(result.getMapping().get(arrayStoreFrame.getObject()));
                                         	localRemove.add(result.getMapping().get(arrayStoreFrame));

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/StringEncryptionTransformer.java
@@ -1,6 +1,9 @@
 package com.javadeobfuscator.deobfuscator.transformers.smoke; 
  
-import com.javadeobfuscator.deobfuscator.analyzer.ArgsAnalyzer;
+import com.javadeobfuscator.deobfuscator.analyzer.AnalyzerResult;
+import com.javadeobfuscator.deobfuscator.analyzer.MethodAnalyzer;
+import com.javadeobfuscator.deobfuscator.analyzer.frame.Frame;
+import com.javadeobfuscator.deobfuscator.analyzer.frame.MethodFrame;
 import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
 import com.javadeobfuscator.deobfuscator.executor.Context;
 import com.javadeobfuscator.deobfuscator.executor.MethodExecutor;
@@ -74,15 +77,10 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
         					}else
         					{
         						//Reverse bytecode to try to get the previous args
-        						ArgsAnalyzer analyzer = new ArgsAnalyzer(methodNode, index - 1, 2);
+        						AnalyzerResult result = MethodAnalyzer.analyze(classNode, methodNode);
         						List<AbstractInsnNode> args = new ArrayList<>();
-        						try
-        						{
-        							args = analyzer.lookupArgs();
-        						}catch(Exception e)
-        						{
-        							
-        						}
+        						for(Frame arg : ((MethodFrame)result.getFrames().get(m).get(0)).getArgs())
+        							args.add(result.getInsnNode(arg));
         						if(args.get(0).getOpcode() == Opcodes.LDC
         							&& ((LdcInsnNode)args.get(0)).cst instanceof String
         							&& Utils.isNumber(args.get(1)))

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/StringEncryptionTransformer.java
@@ -54,7 +54,7 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
                         MethodInsnNode m = (MethodInsnNode) current;
                         String strCl = m.owner;
                         if (m.desc.equals("(Ljava/lang/String;I)Ljava/lang/String;")) {
-        					if (m.getPrevious() != null && Utils.isNumber(m.getPrevious()) 
+        					if (m.getPrevious() != null && Utils.isInteger(m.getPrevious()) 
         						&& m.getPrevious().getPrevious() != null 
         						&& m.getPrevious().getPrevious() instanceof LdcInsnNode
         						&& ((LdcInsnNode)m.getPrevious().getPrevious()).cst instanceof String) {
@@ -83,7 +83,7 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
         							args.add(result.getInsnNode(arg));
         						if(args.get(0).getOpcode() == Opcodes.LDC
         							&& ((LdcInsnNode)args.get(0)).cst instanceof String
-        							&& Utils.isNumber(args.get(1)))
+        							&& Utils.isInteger(args.get(1)))
         						{
         							int number = Utils.getIntValue(args.get(1));
             						String obfString = (String)((LdcInsnNode)args.get(0)).cst;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/HideAccessObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/HideAccessObfuscationTransformer.java
@@ -131,9 +131,9 @@ public class HideAccessObfuscationTransformer extends Transformer<TransformerCon
                                 decryptMethods.add(bootstrapMethod);
 
                                 List<JavaValue> args = new ArrayList<>();
-                                args.add(JavaValue.valueOf(null));
+                                args.add(new JavaObject(null, "java/lang/invoke/MethodHandles$Lookup"));
                                 args.add(JavaValue.valueOf(((InvokeDynamicInsnNode) insn).name));
-                                args.add(JavaValue.valueOf(null));
+                                args.add(new JavaObject(null, "java/lang/invoke/MethodType"));
 
                                 JavaMethodHandle result = MethodExecutor.execute(classNode, bootstrapMethod, args, null, context);
                                 switch (result.type) {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/HideAccessObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/HideAccessObfuscationTransformer.java
@@ -202,22 +202,12 @@ public class HideAccessObfuscationTransformer extends Transformer<TransformerCon
                                                 }
                                                 methodNode.instructions.remove(insn.getPrevious());
                                             }
-                                            //Reverse bytecode analysis to get the previous X arguments
-                                            ArgsAnalyzer analyzer = new ArgsAnalyzer(
-                                                    methodNode, methodNode.instructions.indexOf(insn) - 1,
-                                                    Type.getArgumentTypes(result.getDesc()).length);
-                                            List<AbstractInsnNode> numberArgs;
-                                            try {
-                                                numberArgs = analyzer.lookupArgs();
-                                            } catch (RuntimeException e) {
-                                                numberArgs = new ArrayList<>();
-                                            }
-                                            //Writes the "add" part before the first insn
                                             AbstractInsnNode firstArgInsn;
-                                            if (numberArgs.size() > 0)
-                                                firstArgInsn = numberArgs.get(0);
+                                            if(Type.getArgumentTypes(result.getDesc()).length == 0)
+                                            	firstArgInsn = insn;
                                             else
-                                                firstArgInsn = insn;
+                                            	firstArgInsn = new ArgsAnalyzer(
+                                            		insn.getPrevious(), Type.getArgumentTypes(result.getDesc()).length, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs().getFirstArgInsn();
                                             methodNode.instructions.insertBefore(firstArgInsn, new TypeInsnNode(Opcodes.NEW, result.getClassName()));
                                             methodNode.instructions.insertBefore(firstArgInsn, new InsnNode(Opcodes.DUP));
                                             //The constructor is used to write a desc

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/InvokedynamicTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/InvokedynamicTransformer.java
@@ -152,7 +152,9 @@ public class InvokedynamicTransformer extends Transformer<TransformerConfig> {
                                 MethodInsnNode replacement = null;
                                 switch (result.type) {
                                     case "virtual":
-                                        replacement = new MethodInsnNode(Opcodes.INVOKEVIRTUAL, clazz, result.name, result.desc, false);
+                                        replacement = new MethodInsnNode((classpath.get(clazz).access & Opcodes.ACC_INTERFACE) != 0 ? 
+                                        	 Opcodes.INVOKEINTERFACE : Opcodes.INVOKEVIRTUAL, clazz, result.name, result.desc,
+                                        	 (classpath.get(clazz).access & Opcodes.ACC_INTERFACE) != 0);
                                         break;
                                     case "static":
                                         replacement = new MethodInsnNode(Opcodes.INVOKESTATIC, clazz, result.name, result.desc, false);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/InvokedynamicTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/InvokedynamicTransformer.java
@@ -32,6 +32,7 @@ import com.javadeobfuscator.deobfuscator.executor.defined.types.JavaMethodHandle
 import com.javadeobfuscator.deobfuscator.executor.exceptions.ExecutionException;
 import com.javadeobfuscator.deobfuscator.executor.providers.ComparisonProvider;
 import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
+import com.javadeobfuscator.deobfuscator.executor.values.JavaObject;
 import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -137,9 +138,9 @@ public class InvokedynamicTransformer extends Transformer<TransformerConfig> {
                             ClassNode bootstrapClassNode = classes.get(bootstrap.getOwner());
                             MethodNode bootstrapMethodNode = bootstrapClassNode.methods.stream().filter(mn -> mn.name.equals(bootstrap.getName()) && mn.desc.equals(bootstrap.getDesc())).findFirst().orElse(null);
                             List<JavaValue> args = new ArrayList<>();
-                            args.add(JavaValue.valueOf(null)); //Lookup
+                            args.add(new JavaObject(null, "java/lang/invoke/MethodHandles$Lookup")); //Lookup
                             args.add(JavaValue.valueOf(dyn.name)); //dyn method name
-                            args.add(JavaValue.valueOf(null)); //dyn method type
+                            args.add(new JavaObject(null, "java/lang/invoke/MethodType")); //dyn method type
                             for (Object o : dyn.bsmArgs) {
                                 args.add(JavaValue.valueOf(o));
                             }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ReflectionObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ReflectionObfuscationTransformer.java
@@ -204,7 +204,9 @@ public class ReflectionObfuscationTransformer extends Transformer<TransformerCon
                                         ClassNode cn = result.getDeclaringClass().getClassNode();
                                         MethodNode mn = cn.methods.stream().filter(m -> m.name.equals(result.getName()) && m.desc.startsWith(partDesc)).findFirst().orElse(null);
                                         methodInsnNode.desc = mn.desc;
-                                        methodInsnNode.setOpcode(Modifier.isStatic(mn.access) ? Opcodes.INVOKESTATIC : Opcodes.INVOKEVIRTUAL);
+                                        methodInsnNode.setOpcode(Modifier.isStatic(mn.access) ? Opcodes.INVOKESTATIC : 
+                                        	(cn.access & Opcodes.ACC_INTERFACE) != 0 ? Opcodes.INVOKEINTERFACE : Opcodes.INVOKEVIRTUAL);
+                                        methodInsnNode.itf = methodInsnNode.getOpcode() == Opcodes.INVOKEINTERFACE;
                                         total.incrementAndGet();
                                         int x = (int) ((total.get() * 1.0d / expected) * 100);
                                         if (x != 0 && x % 10 == 0 && !alerted[x - 1]) {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ResourceEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ResourceEncryptionTransformer.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2016 Sam Sun <me@samczsun.com>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.javadeobfuscator.deobfuscator.transformers.stringer;
+
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.executor.Context;
+import com.javadeobfuscator.deobfuscator.executor.MethodExecutor;
+import com.javadeobfuscator.deobfuscator.executor.defined.JVMMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedFieldProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.providers.ComparisonProvider;
+import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
+import com.javadeobfuscator.deobfuscator.executor.values.JavaObject;
+import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.Utils;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.PushbackInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ResourceEncryptionTransformer extends Transformer<TransformerConfig> {
+	@Override
+    public boolean transform() {
+        System.out.println("[Stringer] [ResourceEncryptionTransformer] Starting");
+        int processed = process();
+        System.out.println("[Stringer] [ResourceEncryptionTransformer] Processed " + processed + " resources");
+        System.out.println("[Stringer] [ResourceEncryptionTransformer] Done");
+        return true;
+    }
+
+    private int process() {
+        AtomicInteger total = new AtomicInteger();
+
+        DelegatingProvider provider = new DelegatingProvider();
+        provider.register(new MappedFieldProvider());
+        provider.register(new JVMMethodProvider());
+        provider.register(new MappedMethodProvider(classes));
+
+        provider.register(new ComparisonProvider() {
+            @Override
+            public boolean instanceOf(JavaValue target, Type type, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean checkcast(JavaValue target, Type type, Context context) {
+                return true;
+            }
+
+            @Override
+            public boolean checkEquality(JavaValue first, JavaValue second, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean canCheckInstanceOf(JavaValue target, Type type, Context context) {
+                return false;
+            }
+
+            @Override
+            public boolean canCheckcast(JavaValue target, Type type, Context context) {
+                return true;
+            }
+
+            @Override
+            public boolean canCheckEquality(JavaValue first, JavaValue second, Context context) {
+                return false;
+            }
+        });
+        ClassNode decryptor = null;
+        MethodNode init = null;
+        for(ClassNode classNode : classNodes()) {
+        	MethodNode initTemp = null;
+        	boolean hasInputStream = false;
+        	boolean hasObjectArr = false;
+        	for(FieldNode f : classNode.fields)
+        		if(f.desc.equals("[Ljava/lang/Object;"))
+        			hasObjectArr = true;
+        	List<ClassNode> calls = new ArrayList<>();
+        	if(hasObjectArr)
+        		for(MethodNode m : classNode.methods)
+        			if(m.name.equals("<init>") && m.desc.equals("(Ljava/io/InputStream;)V"))
+        			{
+        				for(AbstractInsnNode ain : m.instructions.toArray())
+							if(ain.getOpcode() == Opcodes.NEW
+								&& classes.containsKey(((TypeInsnNode)ain).desc))
+								calls.add(classes.get(((TypeInsnNode)ain).desc));
+        				initTemp = m;
+        				hasInputStream = true;
+        			}
+        	boolean extendsFilter = classNode.superName.equals("java/io/FilterInputStream");
+        	if(hasInputStream && hasObjectArr && extendsFilter
+        		&& calls.size() == 2 && calls.get(0).superName.equals("java/util/zip/Inflater")
+        		&& calls.get(1).superName.equals("java/io/FilterInputStream"))
+        	{
+        		init = initTemp;
+        		decryptor = classNode;
+        	}
+        }
+        if(decryptor != null)
+        {
+        	Context context = new Context(provider);
+    		context.dictionary = classpath;
+    		//Patch
+    		for(AbstractInsnNode ain : init.instructions.toArray())
+    			if(ain.getOpcode() == Opcodes.INVOKESPECIAL
+    				&& ((MethodInsnNode)ain).owner.equals("java/io/PushbackInputStream")
+    				&& ain.getNext() != null && ain.getNext().getOpcode() == Opcodes.INVOKESPECIAL)
+    			{
+    				init.instructions.insert(ain.getNext(),
+    					new FieldInsnNode(Opcodes.PUTFIELD, decryptor.name, "in", "Ljava/io/InputStream;"));
+    				init.instructions.insert(ain.getNext(), new InsnNode(Opcodes.SWAP));
+    				init.instructions.insert(ain.getNext(), new VarInsnNode(Opcodes.ALOAD, 0));
+    				init.instructions.insert(ain, new InsnNode(Opcodes.DUP_X1));
+    			}
+        	for(Entry<String, byte[]> entry : inputPassthrough.entrySet())
+        	{
+        		JavaValue arg = JavaValue.valueOf(new ByteArrayInputStream(entry.getValue()));
+        		JavaObject instance = new JavaObject(decryptor.name);
+        		MethodExecutor.execute(decryptor, init, Arrays.asList(arg), instance, context);
+        		Object in = context.provider.getField(decryptor.name, "in", "Ljava/io/InputStream;", 
+        			instance, context);
+        		if(!(in instanceof PushbackInputStream) && in instanceof FilterInputStream)
+        		{
+        			try
+        			{
+        				for(AbstractInsnNode ain : init.instructions.toArray())
+        					if(ain.getPrevious() != null && ain.getPrevious().getOpcode() == Opcodes.ALOAD
+        					&& ain.getOpcode() == Opcodes.NEW && classes.containsKey(((TypeInsnNode)ain).desc)
+        					&& ain.getNext() != null && ain.getNext().getOpcode() == Opcodes.DUP
+        					&& ain.getNext().getNext() != null && ain.getNext().getNext().getOpcode() == Opcodes.ALOAD)
+        					{
+		        				byte[] buffer = new byte[4096];
+		        				ByteArrayOutputStream output = new ByteArrayOutputStream();
+		        				ClassNode classNode = classes.get(((TypeInsnNode)ain).desc);
+		        				MethodNode initclass = classNode.methods.stream().filter(m -> m.name.equals("<init>"))
+		        					.findFirst().orElse(null);
+		        				JavaObject inst = new JavaObject(classNode.name);
+		        				MethodExecutor.execute(classNode, initclass, Arrays.asList(JavaValue.valueOf(in),
+		        					instance), inst, context);
+		        				MethodNode read = classNode.methods.stream().filter(m -> m.desc.equals("([B)I") && m.name.equals("read"))
+		        					.findFirst().orElse(null);
+		        				while(true)
+		        				{
+			        				int n = MethodExecutor.execute(classNode, read, Arrays.asList(JavaValue.valueOf(buffer)), 
+			        					inst, context);
+			        				if(n == -1)
+			        					break;
+			        				output.write(buffer, 0, n);
+		        				}
+		        				entry.setValue(output.toByteArray());
+		        				output.close();
+		        				total.incrementAndGet();
+		        				break;
+        					}
+        			}catch(IOException e)
+        			{
+        				Utils.sneakyThrow(e);
+        			}
+        		}
+        	}
+        	//Cleanup
+        	Set<String> remove = new HashSet<>();
+        	for(AbstractInsnNode ain : init.instructions.toArray())
+        		if(ain.getOpcode() == Opcodes.NEW && classes.get(((TypeInsnNode)ain).desc) != null)
+        		remove.add(((TypeInsnNode)ain).desc);
+        	Map<ClassNode, Set<MethodNode>> getResource = new HashMap<>();
+        	for(ClassNode classNode : classNodes())
+        		if(classNode != decryptor)
+        			for(MethodNode methodNode : classNode.methods)
+        			{
+        				AbstractInsnNode ain = methodNode.instructions.getFirst();
+        				if(methodNode.desc.equals("(Ljava/lang/Class;Ljava/lang/String;)Ljava/io/InputStream;")
+        					&& ain != null && ain.getOpcode() == Opcodes.NEW
+        					&& ((TypeInsnNode)ain).desc.equals(decryptor.name))
+        				{
+        					getResource.putIfAbsent(classNode, new HashSet<>());
+        					getResource.get(classNode).add(methodNode);
+        				}
+        				else if(methodNode.desc.equals("(Ljava/lang/Class;Ljava/lang/String;)Ljava/net/URL;")
+        					&& ain != null && ain.getOpcode() == Opcodes.INVOKESTATIC
+        					&& methodNode.instructions.getLast().getPrevious() != null
+        					&& methodNode.instructions.getLast().getPrevious().getOpcode() == Opcodes.INVOKESPECIAL
+        					&& ((MethodInsnNode)methodNode.instructions.getLast().getPrevious()).owner.equals("java/net/URL"))
+        				{
+        					MethodInsnNode methodInsn = (MethodInsnNode)ain;
+        					MethodNode node = classNode.methods.stream().filter(m -> m.name.equals(methodInsn.name)
+        						&& m.desc.equals(methodInsn.desc)).findFirst().orElse(null);
+        					if(node != null)
+        						classNode.methods.remove(node);
+        					getResource.putIfAbsent(classNode, new HashSet<>());
+        					getResource.get(classNode).add(methodNode);
+        				}
+        			}
+        	for(Entry<ClassNode, Set<MethodNode>> entry : getResource.entrySet())
+        		for(MethodNode method : entry.getValue())
+	        		if(method.desc.equals("(Ljava/lang/Class;Ljava/lang/String;)Ljava/net/URL;"))
+	        			for(AbstractInsnNode ain : method.instructions.toArray())
+	        				if(ain.getOpcode() == Opcodes.NEW && classes.containsKey(((TypeInsnNode)ain).desc))
+	        				remove.add(((TypeInsnNode)ain).desc);
+        	Set<String> add = new HashSet<>();
+        	for(String className : remove)
+        		for(MethodNode method : classes.get(className).methods)
+        			for(AbstractInsnNode ain : method.instructions.toArray())
+        				if(ain.getOpcode() == Opcodes.NEW && classes.containsKey(((TypeInsnNode)ain).desc))
+        					add.add(((TypeInsnNode)ain).desc);
+        	remove.addAll(add);
+        	for(ClassNode classNode : classNodes())
+        		if(getResource.containsKey(classNode))
+        			for(MethodNode methodNode : classNode.methods)
+        				for(AbstractInsnNode ain : methodNode.instructions.toArray())
+        					if(ain.getOpcode() == Opcodes.INVOKESTATIC
+        						&& ((MethodInsnNode)ain).owner.equals(classNode.name))
+        					{
+        						MethodNode node = getResource.get(classNode).stream().filter(m -> 
+        						m.name.equals(((MethodInsnNode)ain).name)
+        						&& m.desc.equals(((MethodInsnNode)ain).desc)).findFirst().orElse(null);
+        						if(node != null)
+        						{
+        							String name;
+        							String desc;
+        							if(node.desc.equals("(Ljava/lang/Class;Ljava/lang/String;)Ljava/io/InputStream;"))
+        							{
+        								name = "getResourceAsStream";
+        								desc = "(Ljava/lang/String;)Ljava/io/InputStream;";
+        							}else
+        							{
+        								name = "getResource";
+        								desc = "(Ljava/lang/String;)Ljava/net/URL;";
+        							}
+        							methodNode.instructions.set(ain, new MethodInsnNode(
+        								Opcodes.INVOKEVIRTUAL, "java/lang/Class", name, desc, false));
+        						}
+        					}
+        	remove.add(decryptor.name);
+        	remove.forEach(s -> classes.remove(s));
+        	for(Entry<ClassNode, Set<MethodNode>> entry : getResource.entrySet())
+        		for(MethodNode method : entry.getValue())
+        			entry.getKey().methods.remove(method);
+        }
+        return total.get();
+    }
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ResourceEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/ResourceEncryptionTransformer.java
@@ -158,7 +158,7 @@ public class ResourceEncryptionTransformer extends Transformer<TransformerConfig
 				inflater.inflaterClass = inflaterClassF;
 				return inflater;
 			});
-        	for(Entry<String, byte[]> entry : inputPassthrough.entrySet())
+        	for(Entry<String, byte[]> entry : getDeobfuscator().getInputPassthrough().entrySet())
         	{
         		JavaValue arg = JavaValue.valueOf(new ByteArrayInputStream(entry.getValue()));
         		JavaObject instance = new JavaObject(decryptor.name);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
@@ -424,10 +424,6 @@ public class StringEncryptionTransformer extends Transformer<StringEncryptionTra
     			{
     				previous = previous.getPrevious();
     				continue;
-    			}else if(previous instanceof LabelNode)
-    			{
-    				previous = previous.getPrevious();
-    				continue;
     			}
     			insns.add(previous);
     			if(insns.size() >= 17)
@@ -471,10 +467,6 @@ public class StringEncryptionTransformer extends Transformer<StringEncryptionTra
     		{
     			if(next.getOpcode() == Opcodes.GOTO
     				&& ((JumpInsnNode)next).label == next.getNext())
-    			{
-    				next = next.getNext();
-    				continue;
-    			}else if(next instanceof LabelNode)
     			{
     				next = next.getNext();
     				continue;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
@@ -424,6 +424,10 @@ public class StringEncryptionTransformer extends Transformer<StringEncryptionTra
     			{
     				previous = previous.getPrevious();
     				continue;
+    			}else if(previous instanceof LabelNode)
+    			{
+    				previous = previous.getPrevious();
+    				continue;
     			}
     			insns.add(previous);
     			if(insns.size() >= 17)
@@ -467,6 +471,10 @@ public class StringEncryptionTransformer extends Transformer<StringEncryptionTra
     		{
     			if(next.getOpcode() == Opcodes.GOTO
     				&& ((JumpInsnNode)next).label == next.getNext())
+    			{
+    				next = next.getNext();
+    				continue;
+    			}else if(next instanceof LabelNode)
     			{
     				next = next.getNext();
     				continue;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
@@ -434,17 +434,17 @@ public class StringEncryptionTransformer extends Transformer<StringEncryptionTra
     	if(insns.size() < 17)
     		return null;
     	if(insns.get(1).getOpcode() == Opcodes.IOR
-    		&& Utils.isNumber(insns.get(2))
+    		&& Utils.isInteger(insns.get(2))
     		&& insns.get(3).getOpcode() == Opcodes.ISHL
-    		&& Utils.isNumber(insns.get(4))
-    		&& Utils.isNumber(insns.get(5))
+    		&& Utils.isInteger(insns.get(4))
+    		&& Utils.isInteger(insns.get(5))
     		&& insns.get(6).getOpcode() == Opcodes.CASTORE
     		&& insns.get(7).getOpcode() == Opcodes.I2C
     		&& insns.get(8).getOpcode() == Opcodes.IXOR
-    		&& Utils.isNumber(insns.get(9))
+    		&& Utils.isInteger(insns.get(9))
     		&& insns.get(10).getOpcode() == Opcodes.CALOAD
     		&& insns.get(11).getOpcode() == Opcodes.DUP_X1
-    		&& Utils.isNumber(insns.get(12))
+    		&& Utils.isInteger(insns.get(12))
     		&& insns.get(13).getOpcode() == Opcodes.DUP
     		&& insns.get(14).getOpcode() == Opcodes.DUP
     		&& insns.get(15).getOpcode() == Opcodes.INVOKEVIRTUAL

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/StringEncryptionTransformer.java
@@ -27,7 +27,6 @@ import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
 import com.javadeobfuscator.deobfuscator.executor.values.JavaObject;
 import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
 import com.javadeobfuscator.deobfuscator.transformers.Transformer;
-import com.javadeobfuscator.deobfuscator.transformers.zelix.FlowObfuscationTransformer;
 import com.javadeobfuscator.deobfuscator.utils.Utils;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/TypeStore.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/TypeStore.java
@@ -1,0 +1,47 @@
+package com.javadeobfuscator.deobfuscator.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.javadeobfuscator.deobfuscator.executor.values.JavaObject;
+import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
+
+public class TypeStore
+{
+	 private static final Map<String, Entry<Object, String>> staticFields = Collections.synchronizedMap(new HashMap<>());
+	 private static final Map<Object, Map<String, Entry<Object, String>>> instanceFields = new ConcurrentHashMap<>();
+	 public static final Map<Long, JavaObject> returnObjects = new ConcurrentHashMap<>();
+	 
+	 public static Entry<Object, String> getFieldFromStore(String className, String fieldName, String fieldDesc, JavaValue targetObject) {
+		 if (targetObject == null) {
+			 return staticFields.get(className + fieldName + fieldDesc);
+		 } else {
+			 synchronized (instanceFields) {
+				 Map<String, Entry<Object, String>> field = instanceFields.get(targetObject.value());
+				 if (field != null) {
+					 return field.get(className + fieldName + fieldDesc);
+				 }
+			 }
+			 
+			 return null;
+		 }
+	 }
+
+	 public static void setFieldToStore(String className, String fieldName, String fieldDesc, JavaValue targetObject, Entry<Object, String> value) {
+		 if (targetObject == null) {
+			 staticFields.put(className + fieldName + fieldDesc, value);
+		 } else {
+			 synchronized (instanceFields) {
+				 Map<String, Entry<Object, String>> field = instanceFields.get(targetObject.value());
+				 if (field == null) {
+					 field = new HashMap<>();
+				 }
+				 field.put(className + fieldName + fieldDesc, value);
+				 instanceFields.put(targetObject.value(), field);
+			 }
+		 }
+	 }
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
@@ -266,12 +266,14 @@ public class Utils {
         }
     }
 
-    public static boolean isDigit(String type) {
+    public static boolean canReturnDigit(String type) {
         switch (type) {
             case "I":
             case "S":
             case "B":
             case "J":
+            case "Z":
+            case "C":
                 return true;
             default:
                 return false;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
@@ -346,7 +346,7 @@ public class Utils {
         }); 
     } 
 
-    public static boolean isNumber(AbstractInsnNode ain)
+    public static boolean isInteger(AbstractInsnNode ain)
 	{
 		if(ain.getOpcode() >= Opcodes.ICONST_M1
 			&& ain.getOpcode() <= Opcodes.SIPUSH)
@@ -354,7 +354,7 @@ public class Utils {
 		if(ain instanceof LdcInsnNode)
 		{
 			LdcInsnNode ldc = (LdcInsnNode)ain;
-			if(ldc.cst instanceof Number)
+			if(ldc.cst instanceof Integer)
 				return true;
 		}
 		return false;


### PR DESCRIPTION
+Decrypt encrypted resources by Stringer
+Decrypt encrypted final Strings better
+Skidsuite fixes
+Bugfixes
___
In this PR, I'm changing how MethodExecutor works. Currently, MethodExecutor uses the owner of the method as specified by invokeinterface and invokevirtual. However, JVM uses the owner of the OBJECT in question, and this is why we need to change it.
A side effect of this is that any time a transformer tries to add "null" as an argument, it needs to make sure it gets the class correctly. (e.g. new JavaObject(null, "java/lang/invoke/MethodType"))
___
One problem is that types are not saved throughout, and trying to save types would require massive changes.