### PR TITLE
Updated Allatori Transformers + Stringer Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Official transformers are linked via the `Transformers` class.
 | Transformer | Canonical Name |  Description |
 | --- | --- | --- |
 | Allatori.STRING_ENCRYPTION | allatori.StringEncryptionTransformer | Decrypts strings encrypted by Allatori |
+| Allatori.FLOW_OBFUSCATION | allatori.FlowObfuscationTransformer | Removes flow obfuscation by Allatori |
 | DashO.STRING_ENCRYPTION | dasho.StringEncryptionTransformer | Decrypts strings encrypted by DashO |
 | SkidSuite.STRING_ENCRYPTION | skidsuite2.StringEncryptionTransformer | Decrypts strings encrypted by SkidSuite2 |
 | SkidSuite.FAKE_EXCEPTION | skidsuite2.FakeExceptionTransformer | Remove fake exceptions by SkidSuite2 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ The deobfuscator supports deobfuscation of transformations such as string litera
 
 Things like method names, class names, etc cannot be deobfuscated because their renaming is irreversible. The information needed to deobfuscate is removed.
 
+## My program wasn't deobfuscated
+
+Check out [this guide](CUSTOMTRANSFORMER.md)
+
 ## Examples
 
 ### As a library
@@ -68,6 +72,7 @@ Official transformers are linked via the `Transformers` class.
 | Transformer | Canonical Name |  Description |
 | --- | --- | --- |
 | Allatori.STRING_ENCRYPTION | allatori.StringEncryptionTransformer | Decrypts strings encrypted by Allatori |
+| Allatori.FLOW_OBFUSCATION | allatori.FlowObfuscationTransformer | Removes flow obfuscation by Allatori |
 | DashO.STRING_ENCRYPTION | dasho.StringEncryptionTransformer | Decrypts strings encrypted by DashO |
 | SkidSuite.STRING_ENCRYPTION | skidsuite2.StringEncryptionTransformer | Decrypts strings encrypted by SkidSuite2 |
 | SkidSuite.FAKE_EXCEPTION | skidsuite2.FakeExceptionTransformer | Remove fake exceptions by SkidSuite2 |

--- a/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
@@ -28,7 +28,7 @@ public class ArgsAnalyzer
 	private final AbstractInsnNode start;
 	
 	/**
-	 * What direction should we run?
+	 * How many args do we need?
 	 */
 	private final int argSize;
 	
@@ -42,12 +42,63 @@ public class ArgsAnalyzer
 	 */
 	private final int[] stopCodes;
 	
+	/**
+	 * The breakpoint is a "stop" node that tells the execution to immediately stop if reached.
+	 * Note that any other data such as "difference" will be based on the last node analyzed.
+	 */
+	private AbstractInsnNode breakpoint;
+	
+	/**
+	 * If true, the analyzer will end at the breakpoint (if it is reached)
+	 */
+	private boolean forceBreak;
+	
+	/**
+	 * If true, backward analysis will return the first instance the stack reaches 0, even
+	 * if the node requests more args.
+	 */
+	private boolean ignoreNeeded;
+	private boolean specialDup;
+	
+	/**
+	 * If true, forward analysis will not stop the first time the arg reaches zero, only if the stack size is 0
+	 * AFTER a node.
+	 */
+	private boolean onlyZero;
+	
 	public ArgsAnalyzer(AbstractInsnNode start, int argSize, Mode mode, int... stopCodes)
 	{
+		if(argSize < 0)
+			throw new IllegalArgumentException("Args needed cannot be negative");
 		this.start = start;
 		this.argSize = argSize;
 		this.mode = mode;
 		this.stopCodes = stopCodes;
+	}
+	
+	public void setBreakpoint(AbstractInsnNode breakpoint)
+	{
+		this.breakpoint = breakpoint;
+	}
+	
+	public void setForcebreak(boolean forceBreak)
+	{
+		this.forceBreak = forceBreak;
+	}
+	
+	public void setIgnoreNeeded(boolean ignoreNeeded)
+	{
+		this.ignoreNeeded = ignoreNeeded;
+	}
+	
+	public void setSpecialDup(boolean specialDup)
+	{
+		this.specialDup = specialDup;
+	}
+	
+	public void setOnlyZero(boolean onlyZero)
+	{
+		this.onlyZero = onlyZero;
 	}
 	
 	public Result lookupArgs()
@@ -70,13 +121,16 @@ public class ArgsAnalyzer
     	int diff = 0;
 		int needed = argSize;
 		AbstractInsnNode ain = start;
-		if(needed == 0)
-			return new Result(0, ain, null);
+		AbstractInsnNode swap = null;
+		if(needed == 0 && !forceBreak)
+			return new Result(0, needed, ain, swap, null);
 		while(ain != null)
     	{
 			for(int code : stopCodes)
 				if(ain.getOpcode() == code)
-					return null;
+					return new FailedResult(diff, needed, ain, null);
+			if(breakpoint == ain)
+				return new Result(diff, needed, ain, swap, null);
     		int prevNeeded = needed;
     		if((ain.getOpcode() >= Opcodes.ACONST_NULL && ain.getOpcode() <= Opcodes.ICONST_5)
     			|| (ain.getOpcode() >= Opcodes.FCONST_0 && ain.getOpcode() <= Opcodes.FCONST_2)
@@ -107,11 +161,23 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.CALOAD || ain.getOpcode() == Opcodes.SALOAD)
     		{
     			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 2;
     		}else if(ain.getOpcode() == Opcodes.LALOAD || ain.getOpcode() == Opcodes.DALOAD)
     		{
-    			needed += 2;
     			needed -= 2;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed += 2;
     		}else if(ain.getOpcode() == Opcodes.IASTORE || ain.getOpcode() == Opcodes.FASTORE
     			|| ain.getOpcode() == Opcodes.AASTORE || ain.getOpcode() == Opcodes.BASTORE
     			|| ain.getOpcode() == Opcodes.CASTORE || ain.getOpcode() == Opcodes.SASTORE)
@@ -122,11 +188,72 @@ public class ArgsAnalyzer
     			needed++;
     		else if(ain.getOpcode() == Opcodes.POP2)
     			needed += 2;
-    		else if(ain.getOpcode() == Opcodes.DUP || ain.getOpcode() == Opcodes.DUP_X1 || ain.getOpcode() == Opcodes.DUP_X2)
+    		else if(ain.getOpcode() == Opcodes.DUP)
+    		{
     			needed--;
-    		else if(ain.getOpcode() == Opcodes.DUP2 || ain.getOpcode() == Opcodes.DUP2_X1 || ain.getOpcode() == Opcodes.DUP2_X2)
+    			if(specialDup && needed == 1)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.DUP_X1 && needed != 1 && needed != 2)
+    		{
+    			needed--;
+    			if(needed == 2)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.DUP_X2 && needed != 1 && needed != 2 && needed != 3)
+    		{
+    			needed--;
+    			if(needed == 3)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.DUP2 && needed != 2 && needed != 3)
+    		{
     			needed -= 2;
-    		else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
+    			if(needed == 2)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    		}else if(ain.getOpcode() == Opcodes.DUP2_X1 && needed != 2 && needed != 3 && needed != 4)
+    		{
+    			needed -= 2;
+    			if(needed == 3)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.DUP2_X2 && needed != 2 && needed != 3 && needed != 4 && needed != 5)
+    		{
+    			needed -= 2;
+    			if(needed == 4)
+    			{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.SWAP)
+    		{
+    			if(needed == 2)
+    			{
+        			swap = ain;
+    				needed--;
+    			}else if(needed == 1)
+    			{
+        			swap = ain;
+    				needed++;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
     			|| ain.getOpcode() == Opcodes.IMUL || ain.getOpcode() == Opcodes.IDIV
     			|| ain.getOpcode() == Opcodes.IREM || ain.getOpcode() == Opcodes.ISHL
     			|| ain.getOpcode() == Opcodes.ISHR || ain.getOpcode() == Opcodes.IUSHR
@@ -134,33 +261,72 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.IXOR)
     		{
     			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 2;
     		}else if(ain.getOpcode() == Opcodes.LADD || ain.getOpcode() == Opcodes.LSUB
     			|| ain.getOpcode() == Opcodes.LMUL || ain.getOpcode() == Opcodes.LDIV
-    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LSHL
-    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR
-    			|| ain.getOpcode() == Opcodes.LAND || ain.getOpcode() == Opcodes.LOR
-    			|| ain.getOpcode() == Opcodes.LXOR)
+    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LAND 
+    			|| ain.getOpcode() == Opcodes.LOR || ain.getOpcode() == Opcodes.LXOR)
     		{
     			needed -= 2;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 4;
+    		}else if(ain.getOpcode() == Opcodes.LSHL
+    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR)
+    		{
+    			needed -= 2;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed += 3;
     		}else if(ain.getOpcode() == Opcodes.FADD || ain.getOpcode() == Opcodes.FSUB
     			|| ain.getOpcode() == Opcodes.FMUL || ain.getOpcode() == Opcodes.FDIV
     			|| ain.getOpcode() == Opcodes.FREM || ain.getOpcode() == Opcodes.FCMPL
     			|| ain.getOpcode() == Opcodes.FCMPG)
     		{
     			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 2;
     		}else if(ain.getOpcode() == Opcodes.DADD || ain.getOpcode() == Opcodes.DSUB
     			|| ain.getOpcode() == Opcodes.DMUL || ain.getOpcode() == Opcodes.DDIV
     			|| ain.getOpcode() == Opcodes.DREM)
     		{
     			needed -= 2;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 4;
     		}else if(ain.getOpcode() == Opcodes.LCMP || ain.getOpcode() == Opcodes.DCMPL
     			|| ain.getOpcode() == Opcodes.DCMPG)
     		{
     			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			needed += 4;
     		}else if(ain.getOpcode() == Opcodes.I2L || ain.getOpcode() == Opcodes.I2D
     			|| ain.getOpcode() == Opcodes.F2L || ain.getOpcode() == Opcodes.F2D)
@@ -168,7 +334,31 @@ public class ArgsAnalyzer
     		else if(ain.getOpcode() == Opcodes.L2I || ain.getOpcode() == Opcodes.D2I
     			|| ain.getOpcode() == Opcodes.L2F || ain.getOpcode() == Opcodes.D2F)
     			needed++;
-    		else if(ain.getOpcode() == Opcodes.NEW)
+    		else if(ain.getOpcode() == Opcodes.I2F || ain.getOpcode() == Opcodes.I2B 
+    			|| ain.getOpcode() == Opcodes.I2C || ain.getOpcode() == Opcodes.I2S 
+    			|| ain.getOpcode() == Opcodes.F2I || ain.getOpcode() == Opcodes.INEG 
+    			|| ain.getOpcode() == Opcodes.FNEG)
+    		{
+    			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed++;
+    		}else if(ain.getOpcode() == Opcodes.L2D || ain.getOpcode() == Opcodes.D2L
+    			|| ain.getOpcode() == Opcodes.DNEG || ain.getOpcode() == Opcodes.LNEG)
+    		{
+    			needed -= 2;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed += 2;
+    		}else if(ain.getOpcode() == Opcodes.NEW)
     			needed--;
     		else if(ain.getOpcode() == Opcodes.GETSTATIC || ain.getOpcode() == Opcodes.GETFIELD)
     		{
@@ -177,6 +367,12 @@ public class ArgsAnalyzer
     				needed -= 2;
     			else
     				needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			if(ain.getOpcode() == Opcodes.GETFIELD)
     				needed++;
     		}else if(ain.getOpcode() == Opcodes.PUTSTATIC || ain.getOpcode() == Opcodes.PUTFIELD)
@@ -197,6 +393,12 @@ public class ArgsAnalyzer
     			else if(Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.VOID
     				&& Type.getReturnType(((MethodInsnNode)ain).desc).getSort() != Type.METHOD)
     				needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			if(ain.getOpcode() != Opcodes.INVOKESTATIC)
     				needed++;
     			for(Type t : Type.getArgumentTypes(((MethodInsnNode)ain).desc)) 
@@ -214,6 +416,12 @@ public class ArgsAnalyzer
     			else if(Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.VOID
     				&& Type.getReturnType(((InvokeDynamicInsnNode)ain).desc).getSort() != Type.METHOD)
     				needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
     			for(Type t : Type.getArgumentTypes(((InvokeDynamicInsnNode)ain).desc)) 
     			{
                      if(t.getSort() == Type.LONG || t.getSort() == Type.DOUBLE)
@@ -225,27 +433,69 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.IFNULL || ain.getOpcode() == Opcodes.IFNONNULL 
     			|| ain.getOpcode() == Opcodes.TABLESWITCH || ain.getOpcode() == Opcodes.LOOKUPSWITCH 
     			|| ain.getOpcode() == Opcodes.ATHROW || ain.getOpcode() == Opcodes.RET)
-    			return null;
+    			return new FailedResult(diff, needed, ain, null);
     		else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
-    			return null;
+    			return new FailedResult(diff, needed, ain, null);
     		else if(ain.getOpcode() == Opcodes.GOTO)
-    			return null;
+    			return new FailedResult(diff, needed, ain, null);
     		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
-    			needed += ((MultiANewArrayInsnNode)ain).dims - 1;
-    		else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
+    		{
+    			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed += ((MultiANewArrayInsnNode)ain).dims;		
+    		}else if(ain.getOpcode() == Opcodes.INSTANCEOF)
+    		{
+    			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed++;
+    		}else if(ain.getOpcode() == Opcodes.CHECKCAST)
+    		{
+    			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed++;
+    		}else if(ain.getOpcode() == Opcodes.NEWARRAY || ain.getOpcode() == Opcodes.ANEWARRAY
+    			|| ain.getOpcode() == Opcodes.ARRAYLENGTH)
+    		{
+    			needed--;
+    			if(needed <= 0 && ignoreNeeded)
+        		{
+    				diff = needed - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			needed++;
+    		}else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
     			|| ain.getOpcode() == Opcodes.ARETURN)
-    			return null;	
+    			return new FailedResult(diff, needed, ain, null);
     		else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
-    			return null;	
-    		diff = needed - prevNeeded;
-    		if(needed <= 0)
+    			return new FailedResult(diff, needed, ain, null);
+    		else if(ain.getOpcode() == Opcodes.RETURN)
+    			return new FailedResult(diff, needed, ain, null);
+    		if(Utils.isInstruction(ain))
+    			diff = needed - prevNeeded;
+    		if(needed <= 0 && !forceBreak)
     		{
     			result = ain;
     			break;
     		}
-    		ain = Utils.getPrevious(ain);
+    		ain = ain.getPrevious();
     	}
-		return new Result(diff, result, null);
+		return new Result(diff, needed, result, swap, null);
 	}
 	
 	/**
@@ -259,13 +509,16 @@ public class ArgsAnalyzer
     	int diff = 0;
 		int stackSize = argSize;
 		AbstractInsnNode ain = start;
-		if(stackSize == 0)
-			return new Result(0, ain, skippedDups);
+		AbstractInsnNode swap = null;
+		if(stackSize == 0 && !forceBreak)
+			return new Result(0, stackSize, ain, swap, skippedDups);
 		while(ain != null)
     	{
 			for(int code : stopCodes)
 				if(ain.getOpcode() == code)
-					return null;
+					return new FailedResult(diff, stackSize, ain, skippedDups);
+			if(breakpoint == ain)
+				return new Result(diff, -stackSize, ain, swap, skippedDups);
     		int prevNeeded = stackSize;
     		if((ain.getOpcode() >= Opcodes.ACONST_NULL && ain.getOpcode() <= Opcodes.ICONST_5)
     			|| (ain.getOpcode() >= Opcodes.FCONST_0 && ain.getOpcode() <= Opcodes.FCONST_2)
@@ -296,7 +549,7 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.CALOAD || ain.getOpcode() == Opcodes.SALOAD)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -306,7 +559,7 @@ public class ArgsAnalyzer
     		}else if(ain.getOpcode() == Opcodes.LALOAD || ain.getOpcode() == Opcodes.DALOAD)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -324,26 +577,138 @@ public class ArgsAnalyzer
     		else if(ain.getOpcode() == Opcodes.POP2)
     			stackSize -= 2;
     		else if(ain.getOpcode() == Opcodes.DUP)
-    			stackSize++;
-    		else if(ain.getOpcode() == Opcodes.DUP_X1)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.DUP_X1)
     		{
     			if(stackSize > 2)
-    				stackSize++;
-    			else
+    			{
+    				stackSize--;
+        			if(stackSize <= 0 && !forceBreak && !onlyZero)
+            		{
+        				diff = stackSize - prevNeeded;
+            			result = ain;
+            			break;
+            		}
+        			stackSize += 2;
+    			}else if(stackSize == 1)
+    			{
+    				stackSize--;
+    				if(stackSize <= 0 && !forceBreak && !onlyZero)
+    				{
+    					diff = stackSize - prevNeeded;
+    					result = ain;
+    					break;
+    				}
+    			}else
     				skippedDups.add(ain);
     		}else if(ain.getOpcode() == Opcodes.DUP_X2)
     		{
     			if(stackSize > 3)
-    				stackSize++;
-    			else
+    			{
+    				stackSize--;
+        			if(stackSize <= 0 && !forceBreak && !onlyZero)
+            		{
+        				diff = stackSize - prevNeeded;
+            			result = ain;
+            			break;
+            		}
+        			stackSize += 2;
+    			}else if(stackSize == 1)
+    			{
+    				stackSize--;
+    				if(stackSize <= 0 && !forceBreak && !onlyZero)
+    				{
+    					diff = stackSize - prevNeeded;
+    					result = ain;
+    					break;
+    				}
+    			}else
     				skippedDups.add(ain);
     		}else if(ain.getOpcode() == Opcodes.DUP2)
     		{
     			if(stackSize > 2)
-    				stackSize += 2;
-    		}else if(ain.getOpcode() == Opcodes.DUP2_X1 || ain.getOpcode() == Opcodes.DUP2_X2)
-    			return null;
-    		else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
+    			{
+    				stackSize -= 2;
+        			if(stackSize <= 0 && !forceBreak && !onlyZero)
+            		{
+        				diff = stackSize - prevNeeded;
+            			result = ain;
+            			break;
+            		}
+        			stackSize += 4;
+    			}else
+    			{
+    				stackSize -= 2;
+    				diff = stackSize - prevNeeded;
+    				result = ain;
+    				break;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.DUP2_X1)
+    		{
+    			if(stackSize > 3)
+    			{
+    				stackSize -= 2;
+        			if(stackSize <= 0 && !forceBreak && !onlyZero)
+            		{
+        				diff = stackSize - prevNeeded;
+            			result = ain;
+            			break;
+            		}
+        			stackSize += 4;
+    			}else if(stackSize == 1 || stackSize == 2)
+    			{
+    				stackSize -= 2;
+    				if(stackSize <= 0 && !forceBreak && !onlyZero)
+    				{
+    					diff = stackSize - prevNeeded;
+    					result = ain;
+    					break;
+    				}
+    			}else
+    				skippedDups.add(ain);
+    		}else if(ain.getOpcode() == Opcodes.DUP2_X2)
+    		{
+    			if(stackSize > 4)
+    			{
+    				stackSize -= 2;
+        			if(stackSize <= 0 && !forceBreak && !onlyZero)
+            		{
+        				diff = stackSize - prevNeeded;
+            			result = ain;
+            			break;
+            		}
+        			stackSize += 4;
+    			}else if(stackSize == 1 || stackSize == 2)
+    			{
+    				stackSize -= 2;
+    				if(stackSize <= 0 && !forceBreak && !onlyZero)
+    				{
+    					diff = stackSize - prevNeeded;
+    					result = ain;
+    					break;
+    				}
+    			}else
+    				skippedDups.add(ain);
+    		}else if(ain.getOpcode() == Opcodes.SWAP)
+    		{
+    			if(stackSize == 2)
+    			{
+        			swap = ain;
+    				stackSize--;
+    			}else if(stackSize == 1)
+    			{
+        			swap = ain;
+    				stackSize++;
+    			}
+    		}else if(ain.getOpcode() == Opcodes.IADD || ain.getOpcode() == Opcodes.ISUB
     			|| ain.getOpcode() == Opcodes.IMUL || ain.getOpcode() == Opcodes.IDIV
     			|| ain.getOpcode() == Opcodes.IREM || ain.getOpcode() == Opcodes.ISHL
     			|| ain.getOpcode() == Opcodes.ISHR || ain.getOpcode() == Opcodes.IUSHR
@@ -351,7 +716,7 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.IXOR)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -360,13 +725,22 @@ public class ArgsAnalyzer
     			stackSize++;
     		}else if(ain.getOpcode() == Opcodes.LADD || ain.getOpcode() == Opcodes.LSUB
     			|| ain.getOpcode() == Opcodes.LMUL || ain.getOpcode() == Opcodes.LDIV
-    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LSHL
-    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR
-    			|| ain.getOpcode() == Opcodes.LAND || ain.getOpcode() == Opcodes.LOR
-    			|| ain.getOpcode() == Opcodes.LXOR)
+    			|| ain.getOpcode() == Opcodes.LREM || ain.getOpcode() == Opcodes.LAND 
+    			|| ain.getOpcode() == Opcodes.LOR || ain.getOpcode() == Opcodes.LXOR)
     		{
     			stackSize -= 4;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.LSHL
+    			|| ain.getOpcode() == Opcodes.LSHR || ain.getOpcode() == Opcodes.LUSHR)
+    		{
+    			stackSize -= 3;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -379,7 +753,7 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.FCMPG)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -391,7 +765,7 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.DREM)
     		{
     			stackSize -= 4;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -402,7 +776,7 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.DCMPG)
     		{
     			stackSize -= 4;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -411,17 +785,57 @@ public class ArgsAnalyzer
     			stackSize++;
     		}else if(ain.getOpcode() == Opcodes.I2L || ain.getOpcode() == Opcodes.I2D
     			|| ain.getOpcode() == Opcodes.F2L || ain.getOpcode() == Opcodes.F2D)
-    			stackSize++;
-    		else if(ain.getOpcode() == Opcodes.L2I || ain.getOpcode() == Opcodes.D2I
-    			|| ain.getOpcode() == Opcodes.L2F || ain.getOpcode() == Opcodes.D2F)
+    		{
     			stackSize--;
-    		else if(ain.getOpcode() == Opcodes.NEW)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.L2I || ain.getOpcode() == Opcodes.D2I
+    			|| ain.getOpcode() == Opcodes.L2F || ain.getOpcode() == Opcodes.D2F)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.I2F || ain.getOpcode() == Opcodes.I2B 
+    			|| ain.getOpcode() == Opcodes.I2C || ain.getOpcode() == Opcodes.I2S 
+    			|| ain.getOpcode() == Opcodes.F2I || ain.getOpcode() == Opcodes.INEG 
+    			|| ain.getOpcode() == Opcodes.FNEG)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.L2D || ain.getOpcode() == Opcodes.D2L
+    			|| ain.getOpcode() == Opcodes.DNEG || ain.getOpcode() == Opcodes.LNEG)
+    		{
+    			stackSize -= 2;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize += 2;
+    		}else if(ain.getOpcode() == Opcodes.NEW)
     			stackSize++;
     		else if(ain.getOpcode() == Opcodes.GETSTATIC || ain.getOpcode() == Opcodes.GETFIELD)
     		{
     			if(ain.getOpcode() == Opcodes.GETFIELD)
     				stackSize--;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -453,7 +867,7 @@ public class ArgsAnalyzer
                      else
                     	 stackSize--;
     			}
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -474,7 +888,7 @@ public class ArgsAnalyzer
                      else
                     	 stackSize--;
     			}
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -492,27 +906,37 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.ATHROW || ain.getOpcode() == Opcodes.RET)
     		{
     			stackSize--;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
         			break;
         		}
-    			return null;
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
     		}else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
         			break;
         		}
-    			return null;
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
     		}else if(ain.getOpcode() == Opcodes.INSTANCEOF)
     		{
     			stackSize--;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.CHECKCAST)
+    		{
+    			stackSize--;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -520,14 +944,22 @@ public class ArgsAnalyzer
         		}
     			stackSize++;
     		}else if(ain.getOpcode() == Opcodes.GOTO)
-    			return null;
+    			return new FailedResult(diff, stackSize, ain, skippedDups);
     		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
-    			stackSize -= ((MultiANewArrayInsnNode)ain).dims - 1;
-    		else if(ain.getOpcode() == Opcodes.NEWARRAY || ain.getOpcode() == Opcodes.ANEWARRAY
+    		{
+    			stackSize -= ((MultiANewArrayInsnNode)ain).dims;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
+        		{
+    				diff = stackSize - prevNeeded;
+        			result = ain;
+        			break;
+        		}
+    			stackSize++;
+    		}else if(ain.getOpcode() == Opcodes.NEWARRAY || ain.getOpcode() == Opcodes.ANEWARRAY
     			|| ain.getOpcode() == Opcodes.ARRAYLENGTH)
     		{
     			stackSize--;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
         		{
     				diff = stackSize - prevNeeded;
         			result = ain;
@@ -537,34 +969,36 @@ public class ArgsAnalyzer
     		}else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
     			|| ain.getOpcode() == Opcodes.ARETURN)
     		{
-    			stackSize -= 2;
-    			if(stackSize <= 0)
+    			stackSize--;
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
     			{
     				diff = stackSize - prevNeeded;
     				result = ain;
     				break;
     			}
-    			return null;	
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
     		}else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
     		{
     			stackSize -= 2;
-    			if(stackSize <= 0)
+    			if(stackSize <= 0 && !forceBreak && !onlyZero)
     			{
     				diff = stackSize - prevNeeded;
     				result = ain;
     				break;
     			}
-    			return null;	
-    		}
-    		diff = stackSize - prevNeeded;
-    		if(stackSize <= 0)
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
+    		}else if(ain.getOpcode() == Opcodes.RETURN)
+    			return new FailedResult(diff, stackSize, ain, skippedDups);
+    		if(Utils.isInstruction(ain))
+    			diff = stackSize - prevNeeded;
+    		if(stackSize <= 0 && !forceBreak)
     		{
     			result = ain;
     			break;
     		}
-    		ain = Utils.getNext(ain);
+    		ain = ain.getNext();
     	}
-		return new Result(diff, result, skippedDups);
+		return new Result(diff, -stackSize, result, swap, skippedDups);
 	}
 	
 	public enum Mode
@@ -576,13 +1010,18 @@ public class ArgsAnalyzer
 	public static class Result
 	{
 		private final int diff;
+		private final int argsNeeded;
 		private final AbstractInsnNode firstArgInsn;
+		private final AbstractInsnNode swap;
 		private final List<AbstractInsnNode> skippedDups;
 		
-		public Result(int diff, AbstractInsnNode firstArgInsn, List<AbstractInsnNode> skippedDups)
+		public Result(int diff, int argsNeeded, AbstractInsnNode firstArgInsn, 
+			AbstractInsnNode swap, List<AbstractInsnNode> skippedDups)
 		{
 			this.diff = diff;
+			this.argsNeeded = argsNeeded;
 			this.firstArgInsn = firstArgInsn;
+			this.swap = swap;
 			this.skippedDups = skippedDups;
 		}
 		
@@ -591,14 +1030,91 @@ public class ArgsAnalyzer
 			return diff;
 		}
 		
+		public int getArgsNeeded()
+		{
+			return argsNeeded;
+		}
+		
 		public AbstractInsnNode getFirstArgInsn()
 		{
 			return firstArgInsn;
 		}
 		
+		public AbstractInsnNode getSwap()
+		{
+			return swap;
+		}
+		
 		public List<AbstractInsnNode> getSkippedDups()
 		{
 			return skippedDups;
+		}
+	}
+	
+	public static class FailedResult extends Result
+	{
+		private final int diff;
+		private final int extraArgs;
+		private final AbstractInsnNode failedPoint;
+		private final List<AbstractInsnNode> skippedDups;
+		
+		public FailedResult(int diff, int extraArgs, AbstractInsnNode failedPoint, List<AbstractInsnNode> skippedDups)
+		{
+			super(-1, -1, null, null, null);
+			this.diff = diff;
+			this.extraArgs = extraArgs;
+			this.failedPoint = failedPoint;
+			this.skippedDups = skippedDups;
+		}
+		
+		public AbstractInsnNode getFailedPoint()
+		{
+			return failedPoint;
+		}
+		
+		public int getLastSuccessfulNodeDiff()
+		{
+			return diff;
+		}
+		
+		public int getExtraArgs()
+		{
+			return extraArgs;
+		}
+		
+		public List<AbstractInsnNode> getSkippedDupsAtFailure()
+		{
+			return skippedDups;
+		}
+		
+		@Override
+		public int getDiff()
+		{
+			throw new RuntimeException("ArgsAnalyzer lookup failed");
+		}
+		
+		@Override
+		public int getArgsNeeded()
+		{
+			throw new RuntimeException("ArgsAnalyzer lookup failed");
+		}
+		
+		@Override
+		public AbstractInsnNode getFirstArgInsn()
+		{
+			throw new RuntimeException("ArgsAnalyzer lookup failed");
+		}
+		
+		@Override
+		public AbstractInsnNode getSwap()
+		{
+			throw new RuntimeException("ArgsAnalyzer lookup failed");
+		}
+		
+		@Override
+		public List<AbstractInsnNode> getSkippedDups()
+		{
+			throw new RuntimeException("ArgsAnalyzer lookup failed");
 		}
 	}
 }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
@@ -479,7 +479,9 @@ public class ArgsAnalyzer
         			break;
         		}
     			needed++;
-    		}else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
+    		}else if(ain.getOpcode() == Opcodes.MONITORENTER || ain.getOpcode() == Opcodes.MONITOREXIT)
+    			needed++;
+    		else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
     			|| ain.getOpcode() == Opcodes.ARETURN)
     			return new FailedResult(diff, needed, ain, null);
     		else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
@@ -966,7 +968,9 @@ public class ArgsAnalyzer
         			break;
         		}
     			stackSize++;
-    		}else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
+    		}else if(ain.getOpcode() == Opcodes.MONITORENTER || ain.getOpcode() == Opcodes.MONITOREXIT)
+    			stackSize--;
+    		else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
     			|| ain.getOpcode() == Opcodes.ARETURN)
     		{
     			stackSize--;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/analyzer/ArgsAnalyzer.java
@@ -128,7 +128,7 @@ public class ArgsAnalyzer
     	{
 			for(int code : stopCodes)
 				if(ain.getOpcode() == code)
-					return new FailedResult(diff, needed, ain, null);
+					return new FailedResult(diff, needed, ain, swap, null);
 			if(breakpoint == ain)
 				return new Result(diff, needed, ain, swap, null);
     		int prevNeeded = needed;
@@ -246,10 +246,14 @@ public class ArgsAnalyzer
     		{
     			if(needed == 2)
     			{
+    				if(swap != null)
+    					return new FailedResult(diff, needed, ain, swap, null);
         			swap = ain;
     				needed--;
     			}else if(needed == 1)
     			{
+    				if(swap != null)
+    					return new FailedResult(diff, needed, ain, swap, null);
         			swap = ain;
     				needed++;
     			}
@@ -433,11 +437,11 @@ public class ArgsAnalyzer
     			|| ain.getOpcode() == Opcodes.IFNULL || ain.getOpcode() == Opcodes.IFNONNULL 
     			|| ain.getOpcode() == Opcodes.TABLESWITCH || ain.getOpcode() == Opcodes.LOOKUPSWITCH 
     			|| ain.getOpcode() == Opcodes.ATHROW || ain.getOpcode() == Opcodes.RET)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		else if(ain.getOpcode() == Opcodes.GOTO)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
     		{
     			needed--;
@@ -483,11 +487,11 @@ public class ArgsAnalyzer
     			needed++;
     		else if(ain.getOpcode() == Opcodes.IRETURN || ain.getOpcode() == Opcodes.FRETURN
     			|| ain.getOpcode() == Opcodes.ARETURN)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		else if(ain.getOpcode() == Opcodes.RETURN)
-    			return new FailedResult(diff, needed, ain, null);
+    			return new FailedResult(diff, needed, ain, swap, null);
     		if(Utils.isInstruction(ain))
     			diff = needed - prevNeeded;
     		if(needed <= 0 && !forceBreak)
@@ -518,7 +522,7 @@ public class ArgsAnalyzer
     	{
 			for(int code : stopCodes)
 				if(ain.getOpcode() == code)
-					return new FailedResult(diff, stackSize, ain, skippedDups);
+					return new FailedResult(diff, stackSize, ain, swap, skippedDups);
 			if(breakpoint == ain)
 				return new Result(diff, -stackSize, ain, swap, skippedDups);
     		int prevNeeded = stackSize;
@@ -703,10 +707,14 @@ public class ArgsAnalyzer
     		{
     			if(stackSize == 2)
     			{
+    				if(swap != null)
+    					return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
         			swap = ain;
     				stackSize--;
     			}else if(stackSize == 1)
     			{
+    				if(swap != null)
+    					return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
         			swap = ain;
     				stackSize++;
     			}
@@ -914,7 +922,7 @@ public class ArgsAnalyzer
         			result = ain;
         			break;
         		}
-    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
     		}else if(ain.getOpcode() >= Opcodes.IF_ICMPEQ && ain.getOpcode() <= Opcodes.IF_ACMPNE)
     		{
     			stackSize -= 2;
@@ -924,7 +932,7 @@ public class ArgsAnalyzer
         			result = ain;
         			break;
         		}
-    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
     		}else if(ain.getOpcode() == Opcodes.INSTANCEOF)
     		{
     			stackSize--;
@@ -946,7 +954,7 @@ public class ArgsAnalyzer
         		}
     			stackSize++;
     		}else if(ain.getOpcode() == Opcodes.GOTO)
-    			return new FailedResult(diff, stackSize, ain, skippedDups);
+    			return new FailedResult(diff, stackSize, ain, swap, skippedDups);
     		else if(ain.getOpcode() == Opcodes.MULTIANEWARRAY)
     		{
     			stackSize -= ((MultiANewArrayInsnNode)ain).dims;
@@ -980,7 +988,7 @@ public class ArgsAnalyzer
     				result = ain;
     				break;
     			}
-    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
     		}else if(ain.getOpcode() == Opcodes.LRETURN || ain.getOpcode() == Opcodes.DRETURN)
     		{
     			stackSize -= 2;
@@ -990,9 +998,9 @@ public class ArgsAnalyzer
     				result = ain;
     				break;
     			}
-    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, skippedDups);
+    			return new FailedResult(stackSize - prevNeeded, stackSize, ain, swap, skippedDups);
     		}else if(ain.getOpcode() == Opcodes.RETURN)
-    			return new FailedResult(diff, stackSize, ain, skippedDups);
+    			return new FailedResult(diff, stackSize, ain, swap, skippedDups);
     		if(Utils.isInstruction(ain))
     			diff = stackSize - prevNeeded;
     		if(stackSize <= 0 && !forceBreak)
@@ -1060,14 +1068,16 @@ public class ArgsAnalyzer
 		private final int diff;
 		private final int extraArgs;
 		private final AbstractInsnNode failedPoint;
+		private final AbstractInsnNode swap;
 		private final List<AbstractInsnNode> skippedDups;
 		
-		public FailedResult(int diff, int extraArgs, AbstractInsnNode failedPoint, List<AbstractInsnNode> skippedDups)
+		public FailedResult(int diff, int extraArgs, AbstractInsnNode failedPoint, AbstractInsnNode swap, List<AbstractInsnNode> skippedDups)
 		{
 			super(-1, -1, null, null, null);
 			this.diff = diff;
 			this.extraArgs = extraArgs;
 			this.failedPoint = failedPoint;
+			this.swap = swap;
 			this.skippedDups = skippedDups;
 		}
 		
@@ -1084,6 +1094,11 @@ public class ArgsAnalyzer
 		public int getExtraArgs()
 		{
 			return extraArgs;
+		}
+		
+		public AbstractInsnNode getSwapAtFailure()
+		{
+			return swap;
 		}
 		
 		public List<AbstractInsnNode> getSkippedDupsAtFailure()

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -18,6 +18,7 @@ package com.javadeobfuscator.deobfuscator.executor.defined;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
@@ -74,7 +75,13 @@ public class JVMMethodProvider extends MethodProvider {
             put("clone()Ljava/lang/Object;", (targetObject, args, context) -> {
             	Method clone = Object.class.getDeclaredMethod("clone");
             	clone.setAccessible(true);
-            	return clone.invoke(targetObject.value());
+            	try
+            	{
+            		return clone.invoke(targetObject.value());
+            	}catch(InvocationTargetException e)
+            	{
+            		throw e.getTargetException();
+            	}
             });
             put("<init>()V", (targetObject, args, context) -> {
                 expect(targetObject, targetObject.type()); 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -339,7 +339,7 @@ public class JVMMethodProvider extends MethodProvider {
         put("java/lang/RuntimeException", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("<init>(Ljava/lang/String;)V", (targetObject, args, context) -> {
                 expect(targetObject, "java/lang/RuntimeException");
-                targetObject.initialize(args.get(0).value());
+                targetObject.initialize(new RuntimeException(args.get(0).as(String.class)));
                 return null;
             });
             put("<init>()V", (targetObject, args, context) -> {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/JVMMethodProvider.java
@@ -71,7 +71,7 @@ public class JVMMethodProvider extends MethodProvider {
             });
             put("wait(J)V", (targetObject, args, context) -> {
                 synchronized (targetObject.as(Object.class)) {
-                    targetObject.as(Object.class).wait((long) args.get(0).value());
+                    targetObject.as(Object.class).wait(args.get(0).longValue());
                 }
                 return null;
             });
@@ -465,7 +465,13 @@ public class JVMMethodProvider extends MethodProvider {
                 return null;
             });
             put("hashCode()I", (targetObject, args, context) -> targetObject.as(JavaMethod.class).hashCode());
-            put("invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> targetObject.as(JavaMethod.class).invoke(args.get(0), args.get(1)));
+            put("invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;", (targetObject, args, context) -> {
+            	context.push("java.lang.reflect.Method", "invoke", 0);
+            	context.push("sun.reflect.DelegatingMethodAccessorImpl", "invoke", 0);
+            	context.push("sun.reflect.NativeMethodAccessorImpl", "invoke", 0);
+            	context.push("sun.reflect.NativeMethodAccessorImpl", "invoke0", 0);
+            	return targetObject.as(JavaMethod.class).invoke(args.get(0), args.get(1), context);
+            });
         }});
         put("java/lang/reflect/Field", new HashMap<String, Function3<JavaValue, List<JavaValue>, Context, Object>>() {{
             put("getName()Ljava/lang/String;", (targetObject, args, context) -> targetObject.as(JavaField.class).getName());
@@ -789,6 +795,8 @@ public class JVMMethodProvider extends MethodProvider {
     }
 
     private static JavaClass[] toJavaClass(Object[] arr) {
+    	if(arr == null)
+    		return new JavaClass[0];
         JavaClass[] clazz = new JavaClass[arr.length];
         for (int i = 0; i < arr.length; i++) {
             clazz[i] = (JavaClass) arr[i];

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaClass.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaClass.java
@@ -267,17 +267,29 @@ public class JavaClass {
     public JavaMethod[] getMethods() {
         List<JavaMethod> methods = new ArrayList<>();
         ClassNode node = this.classNode;
+        getMethods0(methods, false);
         while(true)
         {
-	        for (MethodNode methodNode : node.methods) {
-	        	if(!methodNode.name.startsWith("<") && Modifier.isPublic(methodNode.access))
-	        		methods.add(new JavaMethod(this, methodNode));
-	        }
-	        if(node.superName == null)
-	        	break;
-	        node = new JavaClass(node.superName, context).classNode;
+        	for (MethodNode methodNode : node.methods) {
+        		if(!methodNode.name.startsWith("<") && Modifier.isPublic(methodNode.access))
+        			methods.add(new JavaMethod(this, methodNode));
+        	}
+        	if(node.superName == null)
+        		break;
+        	node = new JavaClass(node.superName, context).classNode;
         }
         return methods.toArray(new JavaMethod[methods.size()]);
+    }
+    
+    private void getMethods0(List<JavaMethod> methods, boolean excludeStatic)
+    {
+    	for (MethodNode methodNode : this.classNode.methods) {
+        	if(!methodNode.name.startsWith("<") && Modifier.isPublic(methodNode.access)
+        		&& (!Modifier.isStatic(methodNode.access) || !excludeStatic))
+        		methods.add(new JavaMethod(this, methodNode));
+        }
+    	for(String superItf : classNode.interfaces)
+    		new JavaClass(superItf, context).getMethods0(methods, true);
     }
     
     public JavaConstructor[] getDeclaredConstructors()
@@ -351,17 +363,30 @@ public class JavaClass {
     public JavaField[] getFields() {
         List<JavaField> fields = new ArrayList<>();
         ClassNode node = this.classNode;
-        while(true)
-        {
-	        for (FieldNode fieldNode : node.fields) {
-	        	if(Modifier.isPublic(fieldNode.access))
-	        		fields.add(new JavaField(this, fieldNode));
+        if(Modifier.isInterface(this.classNode.access))
+        	getFields0(fields);
+        else
+	        while(true)
+	        {
+		        for (FieldNode fieldNode : node.fields) {
+		        	if(Modifier.isPublic(fieldNode.access))
+		        		fields.add(new JavaField(this, fieldNode));
+		        }
+		        if(node.superName == null)
+		        	break;
+		        node = new JavaClass(node.superName, context).classNode;
 	        }
-	        if(node.superName == null)
-	        	break;
-	        node = new JavaClass(node.superName, context).classNode;
-        }
         return fields.toArray(new JavaField[fields.size()]);
+    }
+    
+    private void getFields0(List<JavaField> fields)
+    {
+    	for (FieldNode fieldNode : this.classNode.fields) {
+        	if(Modifier.isPublic(fieldNode.access))
+        		fields.add(new JavaField(this, fieldNode));
+        }
+    	for(String superItf : classNode.interfaces)
+    		new JavaClass(superItf, context).getFields0(fields);
     }
     
     public JavaField getDeclaredField(String fieldName) {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/executor/defined/types/JavaMethod.java
@@ -19,6 +19,7 @@ package com.javadeobfuscator.deobfuscator.executor.defined.types;
 import java.util.ArrayList;
 import java.util.List;
 import com.google.common.primitives.Primitives;
+import com.javadeobfuscator.deobfuscator.executor.Context;
 import com.javadeobfuscator.deobfuscator.executor.exceptions.ExecutionException;
 import com.javadeobfuscator.deobfuscator.executor.values.*;
 
@@ -82,7 +83,7 @@ public class JavaMethod {
         return getDeclaringClass().getName().hashCode() ^ getName().hashCode();
     }
 
-    public Object invoke(JavaValue instance, JavaValue argsObject) {
+    public Object invoke(JavaValue instance, JavaValue argsObject, Context context) {
     	Object[] args; 
     	String[] argTypes;
     	if(argsObject.value() == null) 
@@ -159,8 +160,13 @@ public class JavaMethod {
                 }
             }
 
-            if (this.clazz.getContext().provider.canInvokeMethod(this.clazz.getClassNode().name, this.method.name, this.method.desc, instance, argsobjects, this.clazz.getContext())) {
-                return this.clazz.getContext().provider.invokeMethod(this.clazz.getClassNode().name, this.method.name, this.method.desc, instance, argsobjects, this.clazz.getContext());
+            if (context.provider.canInvokeMethod(this.clazz.getClassNode().name, this.method.name, this.method.desc, instance, argsobjects, context)) {
+            	Object o = this.clazz.getContext().provider.invokeMethod(this.clazz.getClassNode().name, this.method.name, this.method.desc, instance, argsobjects, context);
+            	context.pop();
+            	context.pop();
+            	context.pop();
+            	context.pop();
+            	return o;
             }
         } catch (ExecutionException ex) {
             throw ex;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/Transformers.java
@@ -26,6 +26,7 @@ import com.javadeobfuscator.deobfuscator.transformers.normalizer.SourceFileClass
 public class Transformers {
     public static class Allatori {
         public static final Class<? extends Transformer> STRING_ENCRYPTION = com.javadeobfuscator.deobfuscator.transformers.allatori.StringEncryptionTransformer.class;
+        public static final Class<? extends Transformer> FLOW_OBFUSCATION = com.javadeobfuscator.deobfuscator.transformers.allatori.FlowObfuscationTransformer.class;
     }
 
     public static class DashO {

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
@@ -743,6 +743,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
         			{
         				ArgsAnalyzer analyzer = new ArgsAnalyzer(ain.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP);
         				analyzer.setIgnoreNeeded(true);
+        				analyzer.setSpecialDup(true);
         				ArgsAnalyzer.Result res = analyzer.lookupArgs();
         				if(!(res instanceof ArgsAnalyzer.FailedResult) && res.getFirstArgInsn() != null)
         				{
@@ -803,7 +804,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     							}
     							nxt = nxt.getNext();
     						}
-    						if(!hasJumpBetween)
+    						if(!hasJumpBetween && res.getFirstArgInsn().getOpcode() != Opcodes.DUP)
     						{
 	        					int prev = method.instructions.indexOf(ain);
 	        					method.instructions.remove(ain);
@@ -890,7 +891,8 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
         					ArgsAnalyzer analyzer1 = new ArgsAnalyzer(ain.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS);
         					analyzer1.setIgnoreNeeded(true);
             				ArgsAnalyzer.Result res1 = analyzer1.lookupArgs();
-            				if(!(res1 instanceof ArgsAnalyzer.FailedResult) && res1.getFirstArgInsn() != null)
+            				if(!(res instanceof ArgsAnalyzer.FailedResult) 
+            					&& !(res1 instanceof ArgsAnalyzer.FailedResult) && res1.getFirstArgInsn() != null)
             				{
             					if(Utils.getNext(res.getFirstArgInsn()).getOpcode() == Opcodes.DUP)
             						res = new ArgsAnalyzer(Utils.getNext(res.getFirstArgInsn()).getNext(), 1,

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
@@ -276,7 +276,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 	                            	throw new RuntimeException();
 	        					if(res)
 	        					{
-	        						method.instructions.set(ain.getNext(),  new JumpInsnNode(Opcodes.GOTO, ((JumpInsnNode)ain).label));
+	        						method.instructions.set(ain.getNext(),  new JumpInsnNode(Opcodes.GOTO, ((JumpInsnNode)ain.getNext()).label));
 	        						method.instructions.remove(ain);
 	        					}else
 	        					{

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
@@ -2102,18 +2102,20 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     
     private boolean isFailedInline(MethodNode method, AbstractInsnNode start, AbstractInsnNode end)
     {
-    	if(start.getOpcode() != Opcodes.ILOAD)
-    		return false;
-    	int var = ((VarInsnNode)start).var;
-    	while(start != end)
+    	if(start.getOpcode() == Opcodes.ILOAD)
     	{
-    		if(start.getOpcode() == Opcodes.IINC && ((IincInsnNode)start).var == var)
-    			return true;
-    		start = start.getNext();
+	    	int var = ((VarInsnNode)start).var;
+	    	AbstractInsnNode next = start;
+	    	while(next != end)
+	    	{
+	    		if(next.getOpcode() == Opcodes.IINC && ((IincInsnNode)next).var == var)
+	    			return true;
+	    		next = next.getNext();
+	    	}
     	}
     	if(Utils.getNext(start).getOpcode() == Opcodes.DUP || Utils.getNext(start).getOpcode() == Opcodes.DUP2)
     		return true;
-    	ArgsAnalyzer.Result res = new ArgsAnalyzer(start, willPush(start) ? 1 : 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+    	ArgsAnalyzer.Result res = new ArgsAnalyzer(start.getNext(), willPush(start) ? 1 : 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
     	if(res instanceof ArgsAnalyzer.FailedResult)
     	{
     		for(AbstractInsnNode skipped : ((ArgsAnalyzer.FailedResult)res).getSkippedDupsAtFailure())

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
@@ -1,0 +1,1652 @@
+package com.javadeobfuscator.deobfuscator.transformers.allatori; 
+ 
+import com.javadeobfuscator.deobfuscator.analyzer.ArgsAnalyzer;
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.executor.defined.JVMComparisonProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.JVMMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedFieldProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*; 
+ 
+public class FlowObfuscationTransformer extends Transformer<TransformerConfig> 
+{
+    @Override 
+    public boolean transform() throws Throwable {
+    	DelegatingProvider provider = new DelegatingProvider();
+        provider.register(new JVMMethodProvider());
+        provider.register(new JVMComparisonProvider());
+        provider.register(new MappedMethodProvider(classes));
+        provider.register(new MappedFieldProvider());
+
+        AtomicInteger fixed = new AtomicInteger();
+
+        System.out.println("[Allatori] [FlowObfuscationTransformer] Starting");
+        for(ClassNode classNode : classNodes())
+        	for(MethodNode method : classNode.methods)
+        		for(int i = 0; i < method.instructions.size(); i++) 
+        		{
+        			AbstractInsnNode ain = method.instructions.get(i);
+        			if(ain.getOpcode() == Opcodes.GOTO)
+        			{
+                        AbstractInsnNode a = Utils.getNext(ain);
+                        AbstractInsnNode b = Utils.getNext(((JumpInsnNode) ain).label);
+                        if(a == b)
+                        	method.instructions.remove(ain);
+                    }
+        		}
+        for(int run = 0; run < 2; run++)
+        {
+	        for(ClassNode classNode : classNodes())
+	        	for(MethodNode method : classNode.methods)
+	        	{
+	        		boolean modified = false;
+	        		do
+	        		{
+	        			modified = false;
+	        			for(int i = 0; i < method.instructions.size(); i++) 
+	            		{
+	        				AbstractInsnNode ain = method.instructions.get(i);
+	        				if(ain.getOpcode() == Opcodes.DUP && Utils.getNext(ain) != null
+	        					&& (Utils.getNext(ain).getOpcode() == Opcodes.ISTORE
+	        					|| Utils.getNext(ain).getOpcode() == Opcodes.ASTORE
+	        					|| Utils.getNext(ain).getOpcode() == Opcodes.FSTORE))
+	        				{
+	        					AbstractInsnNode label = null;
+	        					boolean isGoto = false;
+	        					AbstractInsnNode store = Utils.getNext(ain);
+	        					AbstractInsnNode next2 = Utils.getNext(ain, 2);
+	        					if(next2.getOpcode() == Opcodes.GOTO)
+	        					{
+	        						label = ((JumpInsnNode)next2).label;
+	        						isGoto = true;
+	        					}
+	        					if(!isGoto)
+	        					{
+		        					AbstractInsnNode nxt = Utils.getNext(ain).getNext();
+		        					while(!Utils.isInstruction(nxt) && !(nxt instanceof LabelNode))
+		        						nxt = nxt.getNext();
+		        					if(nxt instanceof LabelNode)
+		        						label = nxt;
+		        					else
+		        						label = Utils.getNext(ain);
+	        					}
+	        					ArgsAnalyzer.Result argUsage = new ArgsAnalyzer(Utils.getNext(ain), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+	        					if(!(argUsage instanceof ArgsAnalyzer.FailedResult) && argUsage.getFirstArgInsn() instanceof JumpInsnNode)
+	        					{
+	        						boolean containsJump = false;
+	        						AbstractInsnNode next = ain;
+	        						while(next != argUsage.getFirstArgInsn())
+	        						{
+	        							if(next instanceof LabelNode)
+	        							{
+	        								for(AbstractInsnNode a : method.instructions.toArray())
+	        									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == next)
+	        									{
+	        										containsJump = true;
+	        										break;
+	        									}
+	        								if(containsJump)
+	        									break;
+	        							}
+	        							next = next.getNext();
+	        						}
+	        						if(!containsJump)
+	        							continue;
+	        					}
+	        					if(isGoto)
+	    						{
+	    							ArgsAnalyzer backwards = new ArgsAnalyzer(label.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS);
+									backwards.setIgnoreNeeded(true);
+									backwards.setSpecialDup(true);
+									ArgsAnalyzer.Result result = backwards.lookupArgs();
+									if(!(result instanceof ArgsAnalyzer.FailedResult) && result.getDiff() == -1)
+									{
+										AbstractInsnNode res = result.getFirstArgInsn();
+										if(res.getOpcode() >= Opcodes.DUP && res.getOpcode() <= Opcodes.DUP_X2)
+											method.instructions.remove(res);
+										else if(res.getOpcode() == store.getOpcode() - 33)
+											method.instructions.remove(res);
+										else
+											throw new RuntimeException("Unexpected opcode: " + res.getOpcode());
+									}
+	    						}
+	        					for(AbstractInsnNode a : method.instructions.toArray())
+	        						if(a instanceof JumpInsnNode && a != next2 && ((JumpInsnNode)a).label == label)
+	        						{
+	        							ArgsAnalyzer backwards = new ArgsAnalyzer(a.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS);
+	        							backwards.setIgnoreNeeded(true);
+	        							backwards.setSpecialDup(true);
+	        							ArgsAnalyzer.Result result = backwards.lookupArgs();
+	        							if(result.getDiff() == -1)
+	        							{
+	    									AbstractInsnNode res = result.getFirstArgInsn();
+	    									if(res.getOpcode() >= Opcodes.DUP && res.getOpcode() <= Opcodes.DUP_X2)
+	    										method.instructions.remove(res);
+	    									else if(res.getOpcode() == store.getOpcode() - 33)
+	    										method.instructions.remove(res);
+	    									else
+	    										throw new RuntimeException("Unexpected opcode: " + res.getOpcode());
+	    								}
+	    							}
+		        					method.instructions.insert(label, new VarInsnNode(
+		        						store.getOpcode() - 33, ((VarInsnNode)store).var));
+		        					method.instructions.remove(ain);
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(ain.getOpcode() == Opcodes.DUP2 && Utils.getNext(ain) != null
+	        					&& (Utils.getNext(ain).getOpcode() == Opcodes.DSTORE
+	        					|| Utils.getNext(ain).getOpcode() == Opcodes.LSTORE))
+	        				{
+	        					AbstractInsnNode label = null;
+	        					boolean isGoto = false;
+	        					AbstractInsnNode store = Utils.getNext(ain);
+	        					AbstractInsnNode next2 = Utils.getNext(ain, 2);
+	        					if(next2.getOpcode() == Opcodes.GOTO)
+	        					{
+	        						label = ((JumpInsnNode)next2).label;
+	        						isGoto = true;
+	        					}
+	        					if(!isGoto)
+	        					{
+		        					AbstractInsnNode nxt = Utils.getNext(ain).getNext();
+		        					while(!Utils.isInstruction(nxt) && !(nxt instanceof LabelNode))
+		        						nxt = nxt.getNext();
+		        					if(nxt instanceof LabelNode)
+		        						label = nxt;
+		        					else
+		        						label = Utils.getNext(ain);
+	        					}
+	        					ArgsAnalyzer.Result argUsage = new ArgsAnalyzer(Utils.getNext(ain), 4, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+	        					if(!(argUsage instanceof ArgsAnalyzer.FailedResult) && argUsage.getFirstArgInsn() instanceof JumpInsnNode)
+	        					{
+	        						boolean containsJump = false;
+	        						AbstractInsnNode next = ain;
+	        						while(next != argUsage.getFirstArgInsn())
+	        						{
+	        							if(next instanceof LabelNode)
+	        							{
+	        								for(AbstractInsnNode a : method.instructions.toArray())
+	        									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == next)
+	        									{
+	        										containsJump = true;
+	        										break;
+	        									}
+	        								if(containsJump)
+	        									break;
+	        							}
+	        							next = next.getNext();
+	        						}
+	        						if(!containsJump)
+	        							continue;
+	        					}
+	        					if(isGoto)
+	        					{
+	        						ArgsAnalyzer backwards = new ArgsAnalyzer(label.getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS);
+	        						backwards.setIgnoreNeeded(true);
+	        						backwards.setSpecialDup(true);
+	        						ArgsAnalyzer.Result result = backwards.lookupArgs();
+	        						if(result.getDiff() == -2)
+	        						{
+	        							AbstractInsnNode res = result.getFirstArgInsn();
+	        							if(res.getOpcode() >= Opcodes.DUP2 && res.getOpcode() <= Opcodes.DUP2_X2)
+	        								method.instructions.remove(res);
+	        							else if(res.getOpcode() == store.getOpcode() - 33)
+	        								method.instructions.remove(res);
+	        							else
+	        								throw new RuntimeException("Unexpected opcode: " + res.getOpcode());
+	        						}
+	        					}
+	        					for(AbstractInsnNode a : method.instructions.toArray())
+	        						if(a instanceof JumpInsnNode && a != next2 && ((JumpInsnNode)a).label == label)
+	        						{
+	        							ArgsAnalyzer backwards = new ArgsAnalyzer(a.getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS);
+	        							backwards.setIgnoreNeeded(true);
+	        							backwards.setSpecialDup(true);
+	        							ArgsAnalyzer.Result result = backwards.lookupArgs();
+	        							if(result.getDiff() == -2)
+	        							{
+	        								AbstractInsnNode res = result.getFirstArgInsn();
+	        								if(res.getOpcode() >= Opcodes.DUP2 && res.getOpcode() <= Opcodes.DUP2_X2)
+	            								method.instructions.remove(res);
+	            							else if(res.getOpcode() == store.getOpcode() - 33)
+	            								method.instructions.remove(res);
+	            							else
+	            								throw new RuntimeException("Unexpected opcode: " + res.getOpcode());
+	        							}
+	        						}
+	        					method.instructions.insert(label, new VarInsnNode(
+	        						store.getOpcode() - 33, ((VarInsnNode)store).var));
+	        					method.instructions.remove(ain);
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if((ain.getOpcode() == Opcodes.GOTO || 
+	        					(ain.getOpcode() >= Opcodes.IRETURN && ain.getOpcode() <= Opcodes.RETURN))
+	        					&& ain.getNext() != null)
+	        				{
+	        					while(!(ain.getNext() instanceof LabelNode) && ain.getNext() != null)
+	        						method.instructions.remove(ain.getNext());
+	        				}else if(Utils.isInteger(ain) && ain.getNext() != null
+	        					&& ain.getNext().getOpcode() >= Opcodes.IFEQ && ain.getNext().getOpcode() <= Opcodes.IFLE)
+	        				{
+	        					int value = Utils.getIntValue(ain);
+	        					boolean res;
+	        					if(ain.getNext().getOpcode() == Opcodes.IFGE)
+	                                res = value >= 0;
+	                            else if(ain.getNext().getOpcode() == Opcodes.IFGT)
+	                                res = value > 0;
+	                            else if(ain.getNext().getOpcode() == Opcodes.IFLE)
+	                                res = value <= 0;
+	                            else if(ain.getNext().getOpcode() == Opcodes.IFLT)
+	                                res = value < 0;
+	                            else if(ain.getNext().getOpcode() == Opcodes.IFNE)
+	                                res = value != 0;
+	                            else if(ain.getNext().getOpcode() == Opcodes.IFEQ)
+	                                res = value == 0;
+	                            else
+	                            	throw new RuntimeException();
+	        					if(res)
+	        					{
+	        						method.instructions.set(ain.getNext(),  new JumpInsnNode(Opcodes.GOTO, ((JumpInsnNode)ain).label));
+	        						method.instructions.remove(ain);
+	        					}else
+	        					{
+	        						LabelNode label = ((JumpInsnNode)ain.getNext()).label;
+	        						boolean used = false;
+	        						if(Utils.getPrevious(label) == null || Utils.getPrevious(label).getOpcode() != Opcodes.GOTO)
+	        							used = true;
+	        						for(AbstractInsnNode a : method.instructions.toArray())
+	        							if(a != ain.getNext() && a instanceof JumpInsnNode && ((JumpInsnNode)a).label == label)
+	        							{
+	        								used = true;
+	        								break;
+	        							}
+	        						if(!used)
+	        						{
+	        							while(!(label.getNext() instanceof LabelNode))
+	        								method.instructions.remove(label.getNext());
+	        							method.instructions.remove(label);
+	        						}
+	        						method.instructions.remove(ain.getNext());
+	        						method.instructions.remove(ain);
+	        					}
+	        					modified = true;
+	        				}else if(getPossibleSwap(ain, 0) != null)
+	        				{
+	        					List<AbstractInsnNode> instrs = getPossibleSwap(ain, 0);
+	        					method.instructions.remove(instrs.get(2));
+	        					method.instructions.remove(instrs.get(0));
+	        					method.instructions.insert(instrs.get(1), instrs.get(0));
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(getPossibleSwap(ain, 1) != null)
+	        				{
+	        					List<AbstractInsnNode> instrs = getPossibleSwap(ain, 1);
+	        					if(instrs.get(1).getOpcode() == Opcodes.DUP)
+	        						method.instructions.set(instrs.get(1), instrs.get(0).clone(null));
+	        					method.instructions.remove(instrs.get(3));
+	        					method.instructions.remove(instrs.get(0));
+	        					method.instructions.insert(instrs.get(2), instrs.get(0));
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(ain.getOpcode() == Opcodes.SWAP && ain.getNext() != null
+	        					&& ain.getNext().getOpcode() >= Opcodes.IFEQ
+	    						&& ain.getNext().getOpcode() <= Opcodes.IFLE)
+	        				{
+	        					LabelNode label = ((JumpInsnNode)ain.getNext()).label;
+	        					for(AbstractInsnNode ain1 : method.instructions.toArray())
+	        					{
+	        						if(ain1 instanceof JumpInsnNode && ain1 != ain.getNext()
+	        							&& ((JumpInsnNode)ain1).label == label)
+	        						{
+	        							if(ain1.getPrevious().getOpcode() == Opcodes.SWAP)
+	        							{
+	        								method.instructions.remove(ain1.getPrevious().getPrevious());
+	        								method.instructions.remove(ain1.getPrevious());
+	        								continue;
+	        							}
+	        							ArgsAnalyzer.Result analysis = new ArgsAnalyzer(
+	        	    						ain1.getPrevious(), ain1.getOpcode() == Opcodes.GOTO ? 1 
+	        	    							: ain.getNext().getOpcode() >= Opcodes.IFEQ
+	        	    	    						&& ain.getNext().getOpcode() <= Opcodes.IFLE ? 2 : 3, 
+	        	    	    						ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP).lookupArgs();
+	        							method.instructions.remove(analysis.getFirstArgInsn());
+	        						}
+	        					}
+								method.instructions.insert(label, ain.getPrevious().clone(null));
+								method.instructions.insertBefore(Utils.getNext(ain.getNext()), ain.getPrevious().clone(null));
+	        					method.instructions.remove(ain.getPrevious());
+								method.instructions.remove(ain);
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(getPossibleDupPop(ain) != null)
+	        				{
+	        					List<AbstractInsnNode> instrs = getPossibleDupPop(ain);
+	        					method.instructions.remove(instrs.get(2));
+	        					method.instructions.remove(instrs.get(1));
+	        					method.instructions.remove(instrs.get(0));
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(willPush(ain) && ain.getNext() != null && willPush(ain.getNext())
+	        					&& ain.getNext().getNext() != null
+	        					&& ain.getNext().getNext().getOpcode() == Opcodes.DUP2)
+	        				{
+	        					method.instructions.set(ain.getNext().getNext(), new InsnNode(Opcodes.DUP_X1));
+	        					method.instructions.insert(ain, new InsnNode(Opcodes.DUP));
+	        					modified = true;
+	        				}else if(ain.getOpcode() == Opcodes.DUP
+	        					&& willPush(Utils.getPrevious(ain)) && Utils.getPrevious(ain).getOpcode() != Opcodes.NEW)
+	        				{
+	        					method.instructions.set(ain, Utils.getPrevious(ain).clone(null));
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(ain.getOpcode() == Opcodes.DUP2
+	        					&& willPush2(Utils.getPrevious(ain)))
+	        				{
+	        					method.instructions.set(ain, Utils.getPrevious(ain).clone(null));
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if(ain.getOpcode() == Opcodes.DUP2_X2 && willPush2(Utils.getPrevious(ain)))
+	        				{
+	        					ArgsAnalyzer.Result res = new ArgsAnalyzer(ain.getPrevious(), 4, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+	        					method.instructions.insertBefore(res.getFirstArgInsn(), Utils.getPrevious(ain).clone(null));
+	        					method.instructions.remove(ain);
+	        					modified = true;
+	        					fixed.incrementAndGet();
+	        				}else if((ain.getOpcode() == Opcodes.DUP_X1 || ain.getOpcode() == Opcodes.DUP_X2)
+	        					&& willPush(Utils.getPrevious(ain)) && Utils.getPrevious(ain).getOpcode() != Opcodes.NEW)
+	        					if(fixDup(method, ain))
+	        					{
+	        						modified = true;
+	        						fixed.incrementAndGet();
+	        					}
+	            		}
+	        		}while(modified);
+	        	}
+	        for(ClassNode classNode : classNodes())
+	        	for(MethodNode method : classNode.methods)
+	        	{
+	        		boolean modified = false;
+	        		do
+	        		{
+	        			modified = false;
+	        			for(int i = 0; i < method.instructions.size();) 
+	            		{
+	        				AbstractInsnNode ain = method.instructions.get(i);
+	        				if(willPush(ain))
+	            			{
+	            				ArgsAnalyzer.Result result = new ArgsAnalyzer(ain.getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+	            				if(result instanceof ArgsAnalyzer.FailedResult && ((ArgsAnalyzer.FailedResult)result).getFailedPoint().getOpcode() == Opcodes.GOTO)
+	            				{
+	            					AbstractInsnNode jump = ((ArgsAnalyzer.FailedResult)result).getFailedPoint();
+									LabelNode label = ((JumpInsnNode)jump).label;
+	            					boolean failed = false;
+	            					for(AbstractInsnNode ain1 : method.instructions.toArray())
+	            						if(ain1 instanceof JumpInsnNode && ain1 != jump && ((JumpInsnNode)ain1).label == label)
+	            						{
+	            							if(ain1.getOpcode() != Opcodes.GOTO)
+	            							{
+	            								failed = true;
+	            								break;
+	            							}
+	            							ArgsAnalyzer.Result res = new ArgsAnalyzer(ain1.getPrevious(), ((ArgsAnalyzer.FailedResult)result).getExtraArgs(), 
+	            								ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+	            							if(res instanceof ArgsAnalyzer.FailedResult || res.getFirstArgInsn() == null)
+	            							{
+	            								failed = true;
+	            								break;
+	            							}else if(!Utils.prettyprint(ain).equals(Utils.prettyprint(res.getFirstArgInsn())))
+	            							{
+	            								failed = true;
+	            								break;
+	            							}else
+	            							{
+	            								ArgsAnalyzer.Result forward = new ArgsAnalyzer(res.getFirstArgInsn().getNext(), ((ArgsAnalyzer.FailedResult)result).getExtraArgs(), 
+	            									ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+	            								if(!(forward instanceof ArgsAnalyzer.FailedResult) || ((ArgsAnalyzer.FailedResult)forward).getFailedPoint() != ain1)
+	            								{
+	            									failed = true;
+	            									break;
+	            								}
+	            							}
+	            						}
+	    							if(!failed)
+	    							{
+	    								ArgsAnalyzer.Result backwards = new ArgsAnalyzer(label, ((ArgsAnalyzer.FailedResult)result).getExtraArgs(), 
+	    									ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+	    								boolean failed2 = false;
+	    								if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null)
+	        							{
+	        								if(!Utils.prettyprint(ain).equals(Utils.prettyprint(backwards.getFirstArgInsn())))
+	            								failed2 = true;
+	        								else
+	            							{
+	            								ArgsAnalyzer analyzer = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 1, ArgsAnalyzer.Mode.FORWARDS);
+	            								analyzer.setBreakpoint(label);
+	            								ArgsAnalyzer.Result forward = analyzer.lookupArgs();
+	            								if(forward.getArgsNeeded() != -((ArgsAnalyzer.FailedResult)result).getExtraArgs())
+	            									failed2 = true;
+	            							}
+	        							}
+	    								if(failed2)
+	    								{
+	    									i++;
+	    									continue;
+	    								}
+	    								ArgsAnalyzer insertAnalyzer = new ArgsAnalyzer(((JumpInsnNode)jump).label, 
+	    									((ArgsAnalyzer.FailedResult)result).getExtraArgs() - 1, ArgsAnalyzer.Mode.FORWARDS);
+	    								insertAnalyzer.setOnlyZero(true);
+	    								ArgsAnalyzer.Result insert = insertAnalyzer.lookupArgs();
+	    								if(insert instanceof ArgsAnalyzer.FailedResult || insert.getFirstArgInsn() == null
+	    									|| insert.getArgsNeeded() > 0)
+	    								{
+	    									i++;
+	    									continue;
+	    								}
+	    								if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null)
+	    									method.instructions.remove(backwards.getFirstArgInsn());
+	    								for(AbstractInsnNode ain1 : method.instructions.toArray())
+	                						if(ain1 instanceof JumpInsnNode && ain1 != jump && ((JumpInsnNode)ain1).label == label)
+	                						{
+	                							ArgsAnalyzer.Result res = new ArgsAnalyzer(ain1.getPrevious(), ((ArgsAnalyzer.FailedResult)result).getExtraArgs(), 
+	                								ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+	                							method.instructions.remove(res.getFirstArgInsn());
+	                						}
+	        							method.instructions.remove(ain);
+	        								method.instructions.insert(insert.getFirstArgInsn(), ain);
+	        							modified = true;
+	    							}
+	            				}else if(!(result instanceof ArgsAnalyzer.FailedResult))
+	            					inlineArgs(method, ain, result);
+	            			}else if(willPush2(ain))
+	            			{
+	            				ArgsAnalyzer.Result result = new ArgsAnalyzer(ain.getNext(), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+	            				if(!(result instanceof ArgsAnalyzer.FailedResult))
+	            					inlineArgs2(method, ain, result);
+	            			}
+	        				if(method.instructions.get(i) == ain || !willPush(method.instructions.get(i)))
+	        					i++;
+	            		}
+	        		}while(modified);
+	        	}
+        }
+        for(ClassNode classNode : classNodes())
+        	for(MethodNode method : classNode.methods)
+        		for(int i = 0; i < method.instructions.size(); i++) 
+        		{
+        			AbstractInsnNode ain = method.instructions.get(i);
+        			if(ain.getOpcode() == Opcodes.ALOAD && Utils.getNext(ain) != null
+        				&& Utils.getNext(ain).getOpcode() == Opcodes.ALOAD
+        				&& ((VarInsnNode)ain).var == ((VarInsnNode)Utils.getNext(ain)).var)
+        			{
+        				ArgsAnalyzer.Result top = new ArgsAnalyzer(ain.getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				ArgsAnalyzer.Result bottom = new ArgsAnalyzer(Utils.getNext(ain).getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				if(!(top instanceof ArgsAnalyzer.FailedResult) && !(bottom instanceof ArgsAnalyzer.FailedResult)
+        					&& top.getFirstArgInsn().getOpcode() == Opcodes.PUTFIELD
+        					&& bottom.getFirstArgInsn().getOpcode() == Opcodes.GETFIELD)
+        				{
+        					FieldInsnNode get = (FieldInsnNode)top.getFirstArgInsn();
+        					FieldInsnNode set = (FieldInsnNode)top.getFirstArgInsn();
+        					if(get.desc.equals(set.desc) && get.owner.equals(set.owner) && get.name.equals(set.name)
+        						&& Utils.getNext(top.getFirstArgInsn()) != bottom.getFirstArgInsn())
+        					{
+        						method.instructions.set(Utils.getNext(ain), new InsnNode(Opcodes.DUP));
+                				fixed.decrementAndGet();
+        					}
+        				}
+        			}else if(ain.getOpcode() == Opcodes.ALOAD && Utils.getNext(ain) != null
+        				&& Utils.isInteger(Utils.getNext(ain))
+        				&& Utils.getNext(ain, 2) != null && Utils.getNext(ain, 2).getOpcode() == Opcodes.ALOAD
+        				&& ((VarInsnNode)ain).var == ((VarInsnNode)Utils.getNext(ain, 2)).var
+        				&& Utils.isInteger(Utils.getNext(ain, 3))
+        				&& Utils.getIntValue(Utils.getNext(ain)) == Utils.getIntValue(Utils.getNext(ain, 3)))
+        			{
+        				ArgsAnalyzer.Result top1 = new ArgsAnalyzer(ain.getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				ArgsAnalyzer.Result top2 = new ArgsAnalyzer(Utils.getNext(ain).getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				ArgsAnalyzer.Result bottom1 = new ArgsAnalyzer(Utils.getNext(ain, 2).getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				ArgsAnalyzer.Result bottom2 = new ArgsAnalyzer(Utils.getNext(ain, 3).getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        				if(!(top1 instanceof ArgsAnalyzer.FailedResult) && !(bottom1 instanceof ArgsAnalyzer.FailedResult)
+        					&& !(top2 instanceof ArgsAnalyzer.FailedResult) && !(bottom2 instanceof ArgsAnalyzer.FailedResult)
+        					&& top1.getFirstArgInsn().getOpcode() >= Opcodes.IASTORE
+        					&& top1.getFirstArgInsn().getOpcode() <= Opcodes.SASTORE
+        					&& top1.getArgsNeeded() == 0
+        					&& top2.getFirstArgInsn() == top1.getFirstArgInsn()
+        					&& top2.getArgsNeeded() == 1
+        					&& bottom1.getFirstArgInsn().getOpcode() == top1.getFirstArgInsn().getOpcode() - 33
+        					&& bottom1.getArgsNeeded() == 0
+        					&& bottom2.getFirstArgInsn() == bottom1.getFirstArgInsn()
+        					&& bottom2.getArgsNeeded() == 1
+        					&& Utils.getNext(top1.getFirstArgInsn()) != bottom1.getFirstArgInsn())
+        				{
+        					method.instructions.remove(Utils.getNext(ain, 3));
+        					method.instructions.set(Utils.getNext(ain, 2), new InsnNode(Opcodes.DUP2));
+            				fixed.addAndGet(-2);
+        				}
+        			}
+        		}
+        for(ClassNode classNode : classNodes())
+        	for(MethodNode method : classNode.methods)
+        		for(int i = 0; i < method.instructions.size(); i++) 
+        		{
+        			AbstractInsnNode ain = method.instructions.get(i);
+        			if(ain.getOpcode() == Opcodes.POP)
+        			{
+        				ArgsAnalyzer analyzer = new ArgsAnalyzer(ain.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP);
+        				analyzer.setIgnoreNeeded(true);
+        				ArgsAnalyzer.Result res = analyzer.lookupArgs();
+        				if(!(res instanceof ArgsAnalyzer.FailedResult) && res.getFirstArgInsn() != null)
+        				{
+        					if(Utils.getNext(res.getFirstArgInsn()).getOpcode() >= Opcodes.DUP
+        						&& Utils.getNext(res.getFirstArgInsn()).getOpcode() <= Opcodes.DUP2_X2)
+        						res = new ArgsAnalyzer(Utils.getNext(res.getFirstArgInsn()).getNext(), 1,
+        							ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+        					int prev = method.instructions.indexOf(ain);
+        					method.instructions.remove(ain);
+        					method.instructions.insert(res.getFirstArgInsn(), ain);
+        					if(method.instructions.indexOf(ain) != prev)
+        						fixed.incrementAndGet();
+        				}
+        			}else if(ain.getOpcode() == Opcodes.POP2)
+        			{
+        				ArgsAnalyzer analyzer = new ArgsAnalyzer(ain.getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP);
+        				analyzer.setIgnoreNeeded(true);
+        				ArgsAnalyzer.Result res = analyzer.lookupArgs();
+        				if(!(res instanceof ArgsAnalyzer.FailedResult) && res.getFirstArgInsn() != null && res.getDiff() == -2)
+        				{
+        					int prev = method.instructions.indexOf(ain);
+        					method.instructions.remove(ain);
+        					method.instructions.insert(res.getFirstArgInsn(), ain);
+        					if(method.instructions.indexOf(ain) != prev)
+        						fixed.incrementAndGet();
+        				}else
+        				{
+        					ArgsAnalyzer analyzer1 = new ArgsAnalyzer(ain.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS);
+        					analyzer1.setIgnoreNeeded(true);
+            				ArgsAnalyzer.Result res1 = analyzer1.lookupArgs();
+            				if(!(res1 instanceof ArgsAnalyzer.FailedResult) && res1.getFirstArgInsn() != null)
+            				{
+            					if(Utils.getNext(res.getFirstArgInsn()).getOpcode() == Opcodes.DUP)
+            						res = new ArgsAnalyzer(Utils.getNext(res.getFirstArgInsn()).getNext(), 1,
+            							ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+            					if(Utils.getNext(res1.getFirstArgInsn()).getOpcode() == Opcodes.DUP)
+            						res1 = new ArgsAnalyzer(Utils.getNext(res1.getFirstArgInsn()).getNext(), 1,
+            							ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+            					method.instructions.remove(ain);
+            					method.instructions.insert(res1.getFirstArgInsn(), new InsnNode(Opcodes.POP));
+            					method.instructions.insert(res.getFirstArgInsn(), new InsnNode(Opcodes.POP));
+            					fixed.incrementAndGet();
+            				}
+        				}
+        			}else if(ain.getOpcode() == Opcodes.IINC)
+        			{
+        				if(ain.getNext().getOpcode() == Opcodes.TABLESWITCH || ain.getNext().getOpcode() == Opcodes.LOOKUPSWITCH)
+        				{
+        					AbstractInsnNode prev = ain;
+        					while(prev != null)
+        					{
+        						if(prev.getOpcode() == Opcodes.ILOAD && ((VarInsnNode)prev).var == ((IincInsnNode)ain).var)
+        							break;
+        						else if(prev instanceof JumpInsnNode || prev instanceof TableSwitchInsnNode 
+        							|| prev instanceof LookupSwitchInsnNode)
+        							break;
+        						else if(prev instanceof LabelNode && hasJump(prev, method))
+        							break;
+        						prev = prev.getPrevious();
+        					}
+        					method.instructions.remove(ain);
+        					method.instructions.insert(prev, ain);
+        				}else
+        				{
+        					AbstractInsnNode next = ain;
+        					AbstractInsnNode jump = null;
+        					while(next != null)
+        					{
+        						if(next.getOpcode() == Opcodes.ILOAD && ((VarInsnNode)next).var == ((IincInsnNode)ain).var)
+        							break;
+        						else if(next instanceof JumpInsnNode)
+        						{
+        							LabelNode label = ((JumpInsnNode)next).label;
+        							if(label.getNext() != null && 
+        								label.getNext().getOpcode() == Opcodes.ILOAD && ((VarInsnNode)label.getNext()).var == ((IincInsnNode)ain).var)
+        							{
+        								jump = next;
+        								break;
+        							}
+        						}else if(next instanceof TableSwitchInsnNode 
+        							|| next instanceof LookupSwitchInsnNode)
+        							break;
+        						else if(next instanceof LabelNode && hasJump(next, method))
+        							break;
+        						next = next.getNext();
+        					}
+        					if(jump != null)
+        					{
+        						method.instructions.remove(ain);
+        						method.instructions.insertBefore(jump, ain);
+        					}
+        				}
+        			}
+        		}
+        System.out.println("[Allatori] [FlowObfuscationTransformer] Fixed " + fixed + " instructions");
+        System.out.println("[Allatori] [FlowObfuscationTransformer] Done");
+		return true;
+    }
+    
+    private boolean hasJump(AbstractInsnNode ain, MethodNode method)
+	{
+		for(AbstractInsnNode a : method.instructions.toArray())
+			if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == ain)
+				return true;
+		return false;
+	}
+
+	private boolean willPush(AbstractInsnNode ain)
+    {
+    	if(ain.getOpcode() == Opcodes.LDC && (((LdcInsnNode)ain).cst instanceof Long || ((LdcInsnNode)ain).cst instanceof Double))
+    		return false;
+    	return (Utils.willPushToStack(ain.getOpcode()) || ain.getOpcode() == Opcodes.NEW) && ain.getOpcode() != Opcodes.GETSTATIC
+    		&& ain.getOpcode() != Opcodes.LLOAD && ain.getOpcode() != Opcodes.DLOAD;
+    }
+    
+    private boolean willPush2(AbstractInsnNode ain)
+    {
+    	return ain.getOpcode() == Opcodes.LCONST_0 || ain.getOpcode() == Opcodes.LCONST_1
+			|| ain.getOpcode() == Opcodes.DCONST_0 || ain.getOpcode() == Opcodes.DCONST_1
+			|| (ain.getOpcode() == Opcodes.LDC && 
+			(((LdcInsnNode)ain).cst instanceof Long || ((LdcInsnNode)ain).cst instanceof Double))
+			|| ain.getOpcode() == Opcodes.LLOAD || ain.getOpcode() == Opcodes.DLOAD;
+    }
+    
+    private List<AbstractInsnNode> getPossibleDupPop(AbstractInsnNode ain)
+    {
+    	AbstractInsnNode next = ain;
+    	List<AbstractInsnNode> instrs = new ArrayList<>();
+    	while(next != null)
+    	{
+    		if(Utils.isInstruction(next) && next.getOpcode() != Opcodes.IINC)
+    			instrs.add(next);
+    		if(instrs.size() >= 3)
+    			break;
+    		next = next.getNext();
+    	}
+    	if(instrs.size() >= 3 && (willPush(instrs.get(0)) || ain.getOpcode() == Opcodes.DUP) 
+    		&& (willPush(instrs.get(1)) || instrs.get(1).getOpcode() == Opcodes.DUP)
+    		&& instrs.get(2).getOpcode() == Opcodes.POP2)
+    		return instrs;
+    	else
+    		return null;
+    }
+    
+    private List<AbstractInsnNode> getPossibleSwap(AbstractInsnNode ain, int mode)
+    {
+    	AbstractInsnNode next = ain;
+    	List<AbstractInsnNode> instrs = new ArrayList<>();
+    	while(next != null)
+    	{
+    		if(Utils.isInstruction(next) && next.getOpcode() != Opcodes.IINC)
+    			instrs.add(next);
+    		if(instrs.size() >= (mode == 0 ? 3 : 4))
+    			break;
+    		next = next.getNext();
+    	}
+    	if(mode == 0 && instrs.size() >= 3 && willPush(instrs.get(0)) && willPush(instrs.get(1))
+    		&& instrs.get(2).getOpcode() == Opcodes.SWAP)
+    		return instrs;
+    	else if(mode == 1 && instrs.size() >= 4 && willPush(instrs.get(0)) 
+    		&& (willPush(instrs.get(1)) || instrs.get(1).getOpcode() == Opcodes.DUP)
+    		&& instrs.get(2).getOpcode() == Opcodes.GETFIELD
+    		&& Type.getType(((FieldInsnNode)instrs.get(2)).desc).getSort() != Type.LONG
+    		&& Type.getType(((FieldInsnNode)instrs.get(2)).desc).getSort() != Type.DOUBLE
+    		&& instrs.get(3).getOpcode() == Opcodes.SWAP)
+    		return instrs;
+    	else
+    		return null;
+    }
+    
+    private boolean fixDup(MethodNode method, AbstractInsnNode ain)
+    {
+    	AbstractInsnNode dup = ain;
+    	AbstractInsnNode next = Utils.getPrevious(dup);
+    	while(next != dup)
+    	{
+    		if(next instanceof LabelNode)
+    			return false;
+    		next = next.getNext();
+    	}
+    	int stackSize = -1;
+    	if(ain.getOpcode() == Opcodes.DUP_X1)
+    		stackSize = 3;
+    	else if(ain.getOpcode() == Opcodes.DUP_X2)
+    		stackSize = 4;
+    	if(stackSize == -1)
+    		return false;
+    	ArgsAnalyzer.Result res = new ArgsAnalyzer(dup.getNext(), stackSize, ArgsAnalyzer.Mode.FORWARDS, Opcodes.SWAP).lookupArgs();
+    	if(res instanceof ArgsAnalyzer.FailedResult)
+    	{
+    		ArgsAnalyzer.Result prev = new ArgsAnalyzer(Utils.getPrevious(dup), 
+				dup.getOpcode() == Opcodes.DUP_X2 ? 3 : dup.getOpcode() == Opcodes.DUP_X1 
+				? 2 : 0, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP).lookupArgs();
+			if(prev instanceof ArgsAnalyzer.FailedResult || prev.getFirstArgInsn() == null)
+				return false;
+			AbstractInsnNode dupprev = Utils.getPrevious(dup);
+			Map<AbstractInsnNode, List<AbstractInsnNode>> labels = new HashMap<>();
+			while(dupprev != prev.getFirstArgInsn())
+			{
+				if(dupprev instanceof LabelNode)
+					labels.put(dupprev, new ArrayList<>());
+				dupprev = dupprev.getPrevious();
+			}
+			if(labels.size() > 0)
+				for(AbstractInsnNode a : method.instructions.toArray())
+    				if(a instanceof JumpInsnNode && labels.containsKey(((JumpInsnNode)a).label))
+    					labels.get(((JumpInsnNode)a).label).add(a);
+			Map<AbstractInsnNode, List<AbstractInsnNode>> values = new HashMap<>();
+			for(Entry<AbstractInsnNode, List<AbstractInsnNode>> entry : labels.entrySet())
+    			if(entry.getValue().size() > 0)
+    				values.put(entry.getKey(), entry.getValue());
+			if(values.size() > 1)
+				return false;
+			if(values.size() > 0)
+			{
+				Entry<AbstractInsnNode, List<AbstractInsnNode>> ent = values.entrySet().iterator().next();
+				ArgsAnalyzer analyzer = new ArgsAnalyzer(Utils.getPrevious(dup), 0, ArgsAnalyzer.Mode.BACKWARDS);
+				analyzer.setBreakpoint(ent.getKey());
+				analyzer.setForcebreak(true);
+				ArgsAnalyzer.Result r = analyzer.lookupArgs();
+				int needed = r.getArgsNeeded() + (dup.getOpcode() == Opcodes.DUP_X1 ? 2 : 3);
+				for(AbstractInsnNode a : ent.getValue())
+				{
+					ArgsAnalyzer.Result insertPoint = new ArgsAnalyzer(a.getPrevious(), needed, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					method.instructions.insertBefore(insertPoint.getFirstArgInsn(), Utils.getPrevious(dup).clone(null));
+				}
+			}
+			method.instructions.insertBefore(prev.getFirstArgInsn(), Utils.getPrevious(dup).clone(null));
+    		method.instructions.remove(dup);
+			return false;
+    	}
+    	List<AbstractInsnNode> skippedDups = res.getSkippedDups();
+    	AbstractInsnNode result = res.getFirstArgInsn();
+    	int diff = res.getDiff();
+    	if(result != null)
+    	{
+    		AbstractInsnNode insert;
+    		if(-diff - (res.getArgsNeeded() + 1) == 0)
+    		{
+    			method.instructions.insertBefore(result, insert = Utils.getPrevious(dup).clone(null));
+        		method.instructions.remove(dup);
+    		}else
+    		{
+    			ArgsAnalyzer.Result prev = new ArgsAnalyzer(Utils.getPrevious(dup), 
+					dup.getOpcode() == Opcodes.DUP_X2 ? 3 : dup.getOpcode() == Opcodes.DUP_X1 
+					? 2 : 0, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP).lookupArgs();
+    			if(prev instanceof ArgsAnalyzer.FailedResult || prev.getFirstArgInsn() == null)
+    				return false;
+    			AbstractInsnNode dupprev = Utils.getPrevious(dup);
+    			Map<AbstractInsnNode, List<AbstractInsnNode>> labels = new HashMap<>();
+    			while(dupprev != prev.getFirstArgInsn())
+    			{
+    				if(dupprev instanceof LabelNode)
+    					labels.put(dupprev, new ArrayList<>());
+    				dupprev = dupprev.getPrevious();
+    			}
+    			if(labels.size() > 0)
+    				for(AbstractInsnNode a : method.instructions.toArray())
+        				if(a instanceof JumpInsnNode && labels.containsKey(((JumpInsnNode)a).label))
+        					labels.get(((JumpInsnNode)a).label).add(a);
+    			Map<AbstractInsnNode, List<AbstractInsnNode>> values = new HashMap<>();
+    			for(Entry<AbstractInsnNode, List<AbstractInsnNode>> entry : labels.entrySet())
+        			if(entry.getValue().size() > 0)
+        				values.put(entry.getKey(), entry.getValue());
+    			if(values.size() > 1)
+    				return false;
+    			if(values.size() > 0)
+    			{
+    				Entry<AbstractInsnNode, List<AbstractInsnNode>> ent = values.entrySet().iterator().next();
+					ArgsAnalyzer analyzer = new ArgsAnalyzer(Utils.getPrevious(dup), 0, ArgsAnalyzer.Mode.BACKWARDS);
+					analyzer.setBreakpoint(ent.getKey());
+					analyzer.setForcebreak(true);
+					ArgsAnalyzer.Result r = analyzer.lookupArgs();
+					int needed = r.getArgsNeeded() + (dup.getOpcode() == Opcodes.DUP_X1 ? 2 : 3);
+    				for(AbstractInsnNode a : ent.getValue())
+    				{
+    					ArgsAnalyzer.Result insertPoint = new ArgsAnalyzer(a.getPrevious(), needed, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+    					method.instructions.insertBefore(insertPoint.getFirstArgInsn(), Utils.getPrevious(dup).clone(null));
+    				}
+    			}
+				method.instructions.insertBefore(prev.getFirstArgInsn(), insert = Utils.getPrevious(dup).clone(null));
+	    		method.instructions.remove(dup);
+    		}
+    		if(insert != null)
+    		{
+	    		AbstractInsnNode prev = insert.getPrevious();
+	    		while(!Utils.isInstruction(prev) && !(prev instanceof LabelNode))
+	    			prev = prev.getPrevious();
+	    		if(prev instanceof LabelNode)
+	    			for(AbstractInsnNode a : method.instructions.toArray())
+	    				if(a.getOpcode() == Opcodes.GOTO && ((JumpInsnNode)a).label == prev)
+	    				{
+	    					ArgsAnalyzer.Result analysis = new ArgsAnalyzer(
+	    						a.getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS, Opcodes.SWAP).lookupArgs();
+	    					if(analysis instanceof ArgsAnalyzer.FailedResult || analysis.getFirstArgInsn() == null)
+	    						return false;
+	    					if(analysis.getFirstArgInsn().getNext().getOpcode() >= Opcodes.DUP
+	    						&& analysis.getFirstArgInsn().getNext().getOpcode() <= Opcodes.DUP2_X2)
+	    						throw new RuntimeException("Did not expect a dup");
+	    					method.instructions.remove(analysis.getFirstArgInsn());
+	    				}
+    		}else
+    			return false;
+    		final AbstractInsnNode insertF = insert;
+    		skippedDups.removeIf(ins -> method.instructions.indexOf(ins) > method.instructions.indexOf(insertF));
+    		for(AbstractInsnNode insn : skippedDups)
+    			if(insn.getOpcode() == Opcodes.DUP_X2)
+    				method.instructions.set(insn, new InsnNode(Opcodes.DUP_X1));
+    			else if(insn.getOpcode() == Opcodes.DUP_X1)
+    				method.instructions.set(insn, new InsnNode(Opcodes.DUP));
+    			else if(insn.getOpcode() == Opcodes.DUP2_X1)
+    				method.instructions.set(insn, new InsnNode(Opcodes.DUP2));
+    			else if(insn.getOpcode() == Opcodes.DUP2_X2)
+    				method.instructions.set(insn, new InsnNode(Opcodes.DUP2_X1));
+        	return true;
+    	}
+    	return false;
+    }
+    
+    private boolean inlineArgs(MethodNode method, AbstractInsnNode ain, ArgsAnalyzer.Result result)
+    {
+    	if(ain.getOpcode() == Opcodes.NEW || Utils.getNext(ain).getOpcode() == Opcodes.CHECKCAST)
+			return false;
+		boolean cannotInline = false;
+		AbstractInsnNode next = ain;
+		while(next != result.getFirstArgInsn())
+		{
+			if(next instanceof LabelNode)
+			{
+				for(AbstractInsnNode a : method.instructions.toArray())
+					if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == next)
+					{
+						cannotInline = true;
+						break;
+					}else if(a instanceof TableSwitchInsnNode)
+					{
+						for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+							if(l == next)
+							{
+								cannotInline = true;
+								break;
+							}
+						if(((TableSwitchInsnNode)a).dflt == next)
+							cannotInline = true;
+						if(cannotInline)
+							break;
+					}else if(a instanceof LookupSwitchInsnNode)
+					{
+						for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+							if(l == next)
+							{
+								cannotInline = true;
+								break;
+							}
+						if(((LookupSwitchInsnNode)a).dflt == next)
+							cannotInline = true;
+						if(cannotInline)
+							break;
+					}
+				for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+					if(trycatch.start == next || trycatch.end == next || trycatch.handler == next)
+					{
+						cannotInline = true;
+						break;
+					}
+				if(cannotInline)
+					break;
+			}
+			next = next.getNext();
+		}
+		if(!cannotInline)
+		{
+			if(result.getDiff() == -1)
+			{
+				fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+				method.instructions.remove(ain);
+				method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+				if(result.getSwap() != null)
+					method.instructions.remove(result.getSwap());
+				return true;
+			}else if(result.getDiff() == -2)
+			{
+				if(result.getArgsNeeded() == 1)
+				{
+					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+					method.instructions.remove(ain);
+					method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != ain)
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
+    							method.instructions.remove(backwards.getFirstArgInsn());
+    							method.instructions.insertBefore(ain, backwards.getFirstArgInsn());
+    						}
+						}
+					}
+					return true;
+				}else
+				{
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush(backwards.getFirstArgInsn()))
+					{
+						if(backwards.getFirstArgInsn().getOpcode() == Opcodes.NEW)
+						{
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+							return true;
+						}
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != result.getFirstArgInsn())
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
+    							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
+    							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
+    							method.instructions.remove(ain);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+    							method.instructions.remove(backwardsResult);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), backwardsResult);
+    							return true;
+    						}
+						}else
+						{
+							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+    						return true;
+						}
+					}
+				}
+				return false;
+			}else if(result.getDiff() == -3)
+			{
+				if(result.getArgsNeeded() == 2)
+				{
+					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+					method.instructions.remove(ain);
+					method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 3, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush2(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != ain)
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
+    							method.instructions.remove(backwards.getFirstArgInsn());
+    							method.instructions.insertBefore(ain, backwards.getFirstArgInsn());
+    						}
+						}
+					}
+					return true;
+				}else if(result.getArgsNeeded() == 0)
+				{
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush2(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != result.getFirstArgInsn())
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
+    							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
+    							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
+    							method.instructions.remove(ain);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+    							method.instructions.remove(backwardsResult);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), backwardsResult);
+    							return true;
+    						}
+						}else
+						{
+							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+    						return true;
+						}
+					}else if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush(backwards.getFirstArgInsn()))
+					{
+						fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+						method.instructions.remove(ain);
+						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+						return true;
+					}
+				}
+				return false;
+			}else
+				return false;
+		}else
+			return false;
+    }
+    
+    private boolean inlineArgs2(MethodNode method, AbstractInsnNode ain, ArgsAnalyzer.Result result)
+    {
+    	if(ain.getOpcode() == Opcodes.NEW || Utils.getNext(ain).getOpcode() == Opcodes.CHECKCAST)
+			return false;
+		boolean cannotInline = false;
+		AbstractInsnNode next = ain;
+		while(next != result.getFirstArgInsn())
+		{
+			if(next instanceof LabelNode)
+			{
+				for(AbstractInsnNode a : method.instructions.toArray())
+					if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == next)
+					{
+						cannotInline = true;
+						break;
+					}else if(a instanceof TableSwitchInsnNode)
+					{
+						for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+							if(l == next)
+							{
+								cannotInline = true;
+								break;
+							}
+						if(((TableSwitchInsnNode)a).dflt == next)
+							cannotInline = true;
+						if(cannotInline)
+							break;
+					}else if(a instanceof LookupSwitchInsnNode)
+					{
+						for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+							if(l == next)
+							{
+								cannotInline = true;
+								break;
+							}
+						if(((LookupSwitchInsnNode)a).dflt == next)
+							cannotInline = true;
+						if(cannotInline)
+							break;
+					}
+				for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+					if(trycatch.start == next || trycatch.end == next || trycatch.handler == next)
+					{
+						cannotInline = true;
+						break;
+					}
+				if(cannotInline)
+					break;
+			}
+			next = next.getNext();
+		}
+		if(!cannotInline)
+		{
+			if(result.getDiff() == -2)
+			{
+				fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+				method.instructions.remove(ain);
+				method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+				return true;
+			}else if(result.getDiff() == -3)
+			{
+				if(result.getArgsNeeded() == 1)
+				{
+					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+					method.instructions.remove(ain);
+					method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 3, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != ain)
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
+    							method.instructions.remove(backwards.getFirstArgInsn());
+    							method.instructions.insertBefore(ain, backwards.getFirstArgInsn());
+    						}
+						}
+					}
+					return true;
+				}else
+				{
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 1, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush(backwards.getFirstArgInsn()))
+					{
+						if(backwards.getFirstArgInsn().getOpcode() == Opcodes.NEW)
+						{
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+							return true;
+						}
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 1, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != result.getFirstArgInsn())
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
+    							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
+    							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
+    							method.instructions.remove(ain);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+    							method.instructions.remove(backwardsResult);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), backwardsResult);
+    							return true;
+    						}
+						}else
+						{
+							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+    						return true;
+						}
+					}
+				}
+				return false;
+			}else if(result.getDiff() == -4)
+			{
+				if(result.getArgsNeeded() == 2)
+				{
+					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
+					method.instructions.remove(ain);
+					method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 4, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush2(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != ain)
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
+    							method.instructions.remove(backwards.getFirstArgInsn());
+    							method.instructions.insertBefore(ain, backwards.getFirstArgInsn());
+    						}
+						}
+					}
+					return true;
+				}else if(result.getArgsNeeded() == 0)
+				{
+					ArgsAnalyzer.Result backwards = new ArgsAnalyzer(result.getFirstArgInsn().getPrevious(), 2, ArgsAnalyzer.Mode.BACKWARDS).lookupArgs();
+					if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
+						&& willPush2(backwards.getFirstArgInsn()))
+					{
+						ArgsAnalyzer.Result forwards = new ArgsAnalyzer(backwards.getFirstArgInsn().getNext(), 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+						if(forwards.getFirstArgInsn() == result.getFirstArgInsn())
+						{
+							boolean hasJumpBetween = false;
+							AbstractInsnNode nxt = backwards.getFirstArgInsn();
+    						while(nxt != result.getFirstArgInsn())
+    						{
+    							if(nxt instanceof LabelNode)
+    							{
+    								for(AbstractInsnNode a : method.instructions.toArray())
+    									if(a instanceof JumpInsnNode && ((JumpInsnNode)a).label == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}else if(a instanceof TableSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((TableSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((TableSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}else if(a instanceof LookupSwitchInsnNode)
+    									{
+    										for(LabelNode l : ((LookupSwitchInsnNode)a).labels)
+    											if(l == nxt)
+    											{
+    												hasJumpBetween = true;
+    												break;
+    											}
+    										if(((LookupSwitchInsnNode)a).dflt == nxt)
+    											hasJumpBetween = true;
+    										if(hasJumpBetween)
+    											break;
+    									}
+    								for(TryCatchBlockNode trycatch : method.tryCatchBlocks)
+    									if(trycatch.start == nxt || trycatch.end == nxt || trycatch.handler == nxt)
+    									{
+    										hasJumpBetween = true;
+    										break;
+    									}
+    								if(hasJumpBetween)
+    									break;
+    							}
+    							nxt = nxt.getNext();
+    						}
+    						if(!hasJumpBetween)
+    						{
+    							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
+    							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
+    							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
+    							method.instructions.remove(ain);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), ain);
+    							method.instructions.remove(backwardsResult);
+    							method.instructions.insertBefore(result.getFirstArgInsn(), backwardsResult);
+    							return true;
+    						}
+						}else
+						{
+							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
+							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
+							method.instructions.remove(ain);
+    						method.instructions.insertBefore(backwards.getFirstArgInsn(), ain);
+    						return true;
+						}
+					}
+				}
+				return false;
+			}else
+				return false;
+		}else
+			return false;
+    }
+    
+    private AbstractInsnNode fixLocalClash(AbstractInsnNode ain, AbstractInsnNode insPoint, MethodNode method, AbstractInsnNode other)
+    {
+    	if(ain.getOpcode() > Opcodes.ALOAD || ain.getOpcode() < Opcodes.ILOAD)
+    		return other;
+    	AbstractInsnNode store = null;
+    	AbstractInsnNode next = ain;
+    	while(next != insPoint)
+    	{
+    		if(next.getOpcode() >= Opcodes.ISTORE && next.getOpcode() <= Opcodes.ASTORE
+    			&& ((VarInsnNode)next).var == ((VarInsnNode)ain).var)
+    		{
+    			store = next;
+    			break;
+    		}
+    		next = next.getNext();
+    	}
+    	if(store != null)
+    	{
+    		int maxLocal = ((VarInsnNode)store).var;
+    		for(AbstractInsnNode a : method.instructions.toArray())
+    			if(a instanceof VarInsnNode && ((VarInsnNode)a).var > maxLocal)
+    				maxLocal = ((VarInsnNode)a).var;
+    		maxLocal++;
+    		AbstractInsnNode next2 = store;
+    		while(next2 != null)
+    		{
+    			if(next2 instanceof JumpInsnNode && 
+    				method.instructions.indexOf(((JumpInsnNode)next2).label) < method.instructions.indexOf(store))
+    				throw new RuntimeException("Jump before clash found");
+    			if(next2 instanceof VarInsnNode && ((VarInsnNode)next2).var == ((VarInsnNode)store).var)
+    			{
+    				VarInsnNode v = (VarInsnNode)next2;
+    				method.instructions.set(v, next2 = new VarInsnNode(v.getOpcode(), maxLocal));
+    				if(other == v)
+    					other = next2;
+    			}
+    			next2 = next2.getNext();
+    		}
+    	}
+    	return other;
+    }
+} 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/FlowObfuscationTransformer.java
@@ -1321,7 +1321,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 		{
 			if(result.getDiff() == -1)
 			{
-				if(hasIincInBetween(ain, result.getFirstArgInsn()))
+				if(isFailedInline(method, ain, result.getFirstArgInsn()))
 					return false;
 				fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 				method.instructions.remove(ain);
@@ -1333,7 +1333,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 			{
 				if(result.getArgsNeeded() == 1)
 				{
-					if(hasIincInBetween(ain, result.getFirstArgInsn()))
+					if(isFailedInline(method, ain, result.getFirstArgInsn()))
 						return false;
 					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 					method.instructions.remove(ain);
@@ -1394,7 +1394,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
     						if(!hasJumpBetween)
     						{
-    							if(hasIincInBetween(backwards.getFirstArgInsn(), ain))
+    							if(isFailedInline(method, backwards.getFirstArgInsn(), ain))
     								return false;
     							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
     							method.instructions.remove(backwards.getFirstArgInsn());
@@ -1411,7 +1411,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 					{
 						if(backwards.getFirstArgInsn().getOpcode() == Opcodes.NEW)
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
 							method.instructions.remove(ain);
@@ -1471,7 +1471,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						if(!hasJumpBetween)
     						{
     							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
-    							if(hasIincInBetween(ain, result.getFirstArgInsn()) || hasIincInBetween(backwardsResult, result.getFirstArgInsn()))
+    							if(isFailedInline(method, ain, result.getFirstArgInsn()) || isFailedInline(method, backwardsResult, result.getFirstArgInsn()))
     								return false;
     							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
     							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
@@ -1483,7 +1483,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
 						}else
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
@@ -1498,7 +1498,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 			{
 				if(result.getArgsNeeded() == 2)
 				{
-					if(hasIincInBetween(ain, result.getFirstArgInsn()))
+					if(isFailedInline(method, ain, result.getFirstArgInsn()))
 						return false;
 					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 					method.instructions.remove(ain);
@@ -1559,7 +1559,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
     						if(!hasJumpBetween)
     						{
-    							if(hasIincInBetween(backwards.getFirstArgInsn(), ain))
+    							if(isFailedInline(method, backwards.getFirstArgInsn(), ain))
     								return false;
     							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
     							method.instructions.remove(backwards.getFirstArgInsn());
@@ -1627,7 +1627,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						if(!hasJumpBetween)
     						{
     							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
-    							if(hasIincInBetween(ain, result.getFirstArgInsn()) || hasIincInBetween(backwardsResult, result.getFirstArgInsn()))
+    							if(isFailedInline(method, ain, result.getFirstArgInsn()) || isFailedInline(method, backwardsResult, result.getFirstArgInsn()))
     								return false;
     							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
     							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
@@ -1639,7 +1639,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
 						}else
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							inlineArgs2(method, backwards.getFirstArgInsn(), forwards);
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
@@ -1650,7 +1650,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 					}else if(!(backwards instanceof ArgsAnalyzer.FailedResult) && backwards.getFirstArgInsn() != null
 						&& willPush(backwards.getFirstArgInsn()))
 					{
-						if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+						if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 							return false;
 						fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
 						method.instructions.remove(ain);
@@ -1720,7 +1720,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 		{
 			if(result.getDiff() == -2)
 			{
-				if(hasIincInBetween(ain, result.getFirstArgInsn()))
+				if(isFailedInline(method, ain, result.getFirstArgInsn()))
 					return false;
 				fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 				method.instructions.remove(ain);
@@ -1730,7 +1730,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 			{
 				if(result.getArgsNeeded() == 1)
 				{
-					if(hasIincInBetween(ain, result.getFirstArgInsn()))
+					if(isFailedInline(method, ain, result.getFirstArgInsn()))
 						return false;
 					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 					method.instructions.remove(ain);
@@ -1791,7 +1791,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
     						if(!hasJumpBetween)
     						{
-    							if(hasIincInBetween(backwards.getFirstArgInsn(), ain))
+    							if(isFailedInline(method, backwards.getFirstArgInsn(), ain))
     								return false;
     							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
     							method.instructions.remove(backwards.getFirstArgInsn());
@@ -1808,7 +1808,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 					{
 						if(backwards.getFirstArgInsn().getOpcode() == Opcodes.NEW)
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
 							method.instructions.remove(ain);
@@ -1868,7 +1868,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						if(!hasJumpBetween)
     						{
     							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
-    							if(hasIincInBetween(ain, result.getFirstArgInsn()) || hasIincInBetween(backwardsResult, result.getFirstArgInsn()))
+    							if(isFailedInline(method, ain, result.getFirstArgInsn()) || isFailedInline(method, backwardsResult, result.getFirstArgInsn()))
     								return false;
     							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
     							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
@@ -1880,7 +1880,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
 						}else
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							inlineArgs(method, backwards.getFirstArgInsn(), forwards);
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
@@ -1895,7 +1895,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
 			{
 				if(result.getArgsNeeded() == 2)
 				{
-					if(hasIincInBetween(ain, result.getFirstArgInsn()))
+					if(isFailedInline(method, ain, result.getFirstArgInsn()))
 						return false;
 					fixLocalClash(ain, result.getFirstArgInsn(), method, null);
 					method.instructions.remove(ain);
@@ -1956,7 +1956,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
     						if(!hasJumpBetween)
     						{
-    							if(hasIincInBetween(backwards.getFirstArgInsn(), ain))
+    							if(isFailedInline(method, backwards.getFirstArgInsn(), ain))
     								return false;
     							fixLocalClash(backwards.getFirstArgInsn(), ain, method, null);
     							method.instructions.remove(backwards.getFirstArgInsn());
@@ -2024,7 +2024,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						if(!hasJumpBetween)
     						{
     							AbstractInsnNode backwardsResult = backwards.getFirstArgInsn();
-    							if(hasIincInBetween(ain, result.getFirstArgInsn()) || hasIincInBetween(backwardsResult, result.getFirstArgInsn()))
+    							if(isFailedInline(method, ain, result.getFirstArgInsn()) || isFailedInline(method, backwardsResult, result.getFirstArgInsn()))
     								return false;
     							ain = fixLocalClash(backwards.getFirstArgInsn(), result.getFirstArgInsn(), method, ain);
     							backwardsResult = fixLocalClash(ain, result.getFirstArgInsn(), method, backwardsResult);
@@ -2036,7 +2036,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     						}
 						}else
 						{
-							if(hasIincInBetween(ain, backwards.getFirstArgInsn()))
+							if(isFailedInline(method, ain, backwards.getFirstArgInsn()))
 								return false;
 							inlineArgs2(method, backwards.getFirstArgInsn(), forwards);
 							fixLocalClash(ain, backwards.getFirstArgInsn(), method, null);
@@ -2100,7 +2100,7 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     	return other;
     }
     
-    private boolean hasIincInBetween(AbstractInsnNode start, AbstractInsnNode end)
+    private boolean isFailedInline(MethodNode method, AbstractInsnNode start, AbstractInsnNode end)
     {
     	if(start.getOpcode() != Opcodes.ILOAD)
     		return false;
@@ -2110,6 +2110,28 @@ public class FlowObfuscationTransformer extends Transformer<TransformerConfig>
     		if(start.getOpcode() == Opcodes.IINC && ((IincInsnNode)start).var == var)
     			return true;
     		start = start.getNext();
+    	}
+    	if(Utils.getNext(start).getOpcode() == Opcodes.DUP || Utils.getNext(start).getOpcode() == Opcodes.DUP2)
+    		return true;
+    	ArgsAnalyzer.Result res = new ArgsAnalyzer(start, willPush(start) ? 1 : 2, ArgsAnalyzer.Mode.FORWARDS).lookupArgs();
+    	if(res instanceof ArgsAnalyzer.FailedResult)
+    	{
+    		for(AbstractInsnNode skipped : ((ArgsAnalyzer.FailedResult)res).getSkippedDupsAtFailure())
+    			if(method.instructions.indexOf(skipped) < method.instructions.indexOf(end))
+    				return true;
+    		if(((ArgsAnalyzer.FailedResult)res).getSwapAtFailure() != null)
+    			if(method.instructions.indexOf(((ArgsAnalyzer.FailedResult)res).getSwapAtFailure()) < method.instructions.indexOf(end))
+    				return true;
+    	}else
+    	{
+    		if(res.getFirstArgInsn().getOpcode() == Opcodes.DUP || res.getFirstArgInsn().getOpcode() == Opcodes.DUP2)
+    			return true;
+    		for(AbstractInsnNode skipped : res.getSkippedDups())
+    			if(method.instructions.indexOf(skipped) < method.instructions.indexOf(end))
+    				return true;
+    		if(res.getSwap() != null)
+    			if(method.instructions.indexOf(res.getSwap()) < method.instructions.indexOf(end))
+    				return true;
     	}
     	return false;
     }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/LightFlowObfuscationTransfomer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/LightFlowObfuscationTransfomer.java
@@ -1,0 +1,65 @@
+package com.javadeobfuscator.deobfuscator.transformers.allatori;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.executor.defined.JVMComparisonProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.JVMMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedFieldProvider;
+import com.javadeobfuscator.deobfuscator.executor.defined.MappedMethodProvider;
+import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.Utils;
+
+public class LightFlowObfuscationTransformer extends Transformer<TransformerConfig> 
+{
+	@Override 
+    public boolean transform() throws Throwable {
+    	DelegatingProvider provider = new DelegatingProvider();
+        provider.register(new JVMMethodProvider());
+        provider.register(new JVMComparisonProvider());
+        provider.register(new MappedMethodProvider(classes));
+        provider.register(new MappedFieldProvider());
+
+        AtomicInteger fixed = new AtomicInteger();
+
+        System.out.println("[Allatori] [LightFlowObfuscationTransformer] Starting");
+        for(ClassNode classNode : classNodes())
+        	for(MethodNode method : classNode.methods)
+        	{
+        		boolean modified;
+        		do
+        		{
+        			modified = false;
+	        		for(AbstractInsnNode ain : method.instructions.toArray())
+	        			if((willPush(ain) || ain.getOpcode() == Opcodes.DUP) && ain.getNext() != null 
+	        			&& (willPush(ain.getNext()) || ain.getNext().getOpcode() == Opcodes.DUP)
+	        				&& ain.getNext().getNext() != null && ain.getNext().getNext().getOpcode() == Opcodes.POP2)
+	        			{
+	        				method.instructions.remove(ain.getNext().getNext());
+	        				method.instructions.remove(ain.getNext());
+	        				method.instructions.remove(ain);
+	        				modified = true;
+	        				fixed.incrementAndGet();
+	        			}
+        		}while(modified);
+        	}
+        System.out.println("[Allatori] [LightFlowObfuscationTransformer] Removed " + fixed + " dead instructions");
+        System.out.println("[Allatori] [LightFlowObfuscationTransformer] Done");
+        return true;
+	}
+	
+	private boolean willPush(AbstractInsnNode ain)
+    {
+    	if(ain.getOpcode() == Opcodes.LDC && (((LdcInsnNode)ain).cst instanceof Long || ((LdcInsnNode)ain).cst instanceof Double))
+    		return false;
+    	return Utils.willPushToStack(ain.getOpcode()) && ain.getOpcode() != Opcodes.GETSTATIC
+    		&& ain.getOpcode() != Opcodes.LLOAD && ain.getOpcode() != Opcodes.DLOAD;
+    }
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/StringEncryptionTransformer.java
@@ -151,8 +151,8 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
     			insnCount.get(Opcodes.NEWARRAY) == null ||
     			invokeCount.get("charAt") == null || invokeCount.get("length") == null)
     			return false;
-        return ((int) ((insnCount.get(Opcodes.IXOR).get() * 100.0f) / 8)) >= 50 &&
-                ((int) ((insnCount.get(Opcodes.ISHL).get() * 100.0f) / 4)) >= 50 &&
+        return ((int) ((insnCount.get(Opcodes.IXOR).get() * 100.0f) / 8)) >= 12 &&
+                ((int) ((insnCount.get(Opcodes.ISHL).get() * 100.0f) / 4)) >= 25 &&
                 ((int) ((insnCount.get(Opcodes.NEWARRAY).get() * 100.0f) / 1)) >= 100 &&
                 ((int) ((invokeCount.get("charAt").get() * 100.0f) / 4)) >= 50 &&
                 ((int) ((invokeCount.get("length").get() * 100.0f) / 2)) >= 50;

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
@@ -27,8 +27,6 @@ import com.javadeobfuscator.deobfuscator.utils.Utils;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.objectweb.asm.Opcodes.*;
-
 @TransformerConfig.ConfigOptions(configClass = ConstantFolder.Config.class)
 public class ConstantFolder extends Transformer<ConstantFolder.Config> {
 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/ConstantFolder.java
@@ -98,7 +98,7 @@ public class ConstantFolder extends Transformer<ConstantFolder.Config> {
                                 if (results.size() == 1) {
                                     InsnList replacement = new InsnList();
                                     replacement.add(new InsnNode(POP2)); // remove existing args from stack
-                                    replacement.add(new LdcInsnNode(results.iterator().next()));
+                                    replacement.add(Utils.getNumberInsn(results.iterator().next()));
                                     replacements.put(ain, replacement);
                                     folded.getAndIncrement();
                                 }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/NumberObfuscationTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/smoke/NumberObfuscationTransformer.java
@@ -164,14 +164,34 @@ public class NumberObfuscationTransformer extends Transformer<TransformerConfig>
 
     private void setNumber(InsnList insns, AbstractInsnNode insn, Integer number) {
         switch (number) {
+        	case -1:
+        		insns.set(insn, new InsnNode(Opcodes.ICONST_M1));
+        		break;
             case 0:
                 insns.set(insn, new InsnNode(Opcodes.ICONST_0));
                 break;
             case 1:
                 insns.set(insn, new InsnNode(Opcodes.ICONST_1));
                 break;
+            case 2:
+            	 insns.set(insn, new InsnNode(Opcodes.ICONST_2));
+            	 break;
+            case 3:
+            	 insns.set(insn, new InsnNode(Opcodes.ICONST_3));
+            	 break;
+            case 4:
+            	 insns.set(insn, new InsnNode(Opcodes.ICONST_4));
+            	 break;
+            case 5:
+            	 insns.set(insn, new InsnNode(Opcodes.ICONST_5));
+            	 break;
             default:
-                insns.set(insn, new LdcInsnNode(number));
+            	if(number >= -128 && number <= 127)
+            		insns.set(insn, new IntInsnNode(Opcodes.BIPUSH, number));
+            	else if(number >= -32768 && number <= 32767)
+            		insns.set(insn, new IntInsnNode(Opcodes.SIPUSH, number));
+            	else
+            		insns.set(insn, new LdcInsnNode(number));
         }
     }
 }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
@@ -59,6 +59,13 @@ public class Utils {
         return next;
     }
 
+    public static AbstractInsnNode getNext(AbstractInsnNode node, int amount) {
+        for (int i = 0; i < amount; i++) {
+            node = getNext(node);
+        }
+        return node;
+    }
+    
     public static AbstractInsnNode getNext(AbstractInsnNode node) {
         AbstractInsnNode next = node.getNext();
         while (!Utils.isInstruction(next)) {
@@ -321,8 +328,10 @@ public class Utils {
         return newInsnList;
     }
 
-    public static AbstractInsnNode getNumberInsn(short num) {
+    public static AbstractInsnNode getNumberInsn(int num) {
         switch (num) {
+        	case -1:
+        		return new InsnNode(Opcodes.ICONST_M1);
             case 0:
                 return new InsnNode(Opcodes.ICONST_0);
             case 1:
@@ -336,7 +345,12 @@ public class Utils {
             case 5:
                 return new InsnNode(Opcodes.ICONST_5);
             default:
-                return new IntInsnNode(Opcodes.SIPUSH, num);
+            	if(num >= -128 && num <= 127)
+            		return new IntInsnNode(Opcodes.BIPUSH, num);
+            	else if(num >= -32768 && num <= 32767)
+            		return new IntInsnNode(Opcodes.SIPUSH, num);
+            	else
+            		return new LdcInsnNode(num);
         }
     }
     
@@ -352,6 +366,7 @@ public class Utils {
 
     public static boolean isInteger(AbstractInsnNode ain)
 	{
+    	if (ain == null) return false;
 		if(ain.getOpcode() >= Opcodes.ICONST_M1
 			&& ain.getOpcode() <= Opcodes.SIPUSH)
 			return true;
@@ -369,10 +384,8 @@ public class Utils {
 		if(node.getOpcode() >= Opcodes.ICONST_M1
 			&& node.getOpcode() <= Opcodes.ICONST_5)
 			return node.getOpcode() - 3;
-		if (node.getOpcode() == Opcodes.BIPUSH) {
-		    return ((IntInsnNode) node).operand;
-        }
-		if(node.getOpcode() == Opcodes.SIPUSH)
+		if(node.getOpcode() == Opcodes.SIPUSH
+			|| node.getOpcode() == Opcodes.BIPUSH)
 			return ((IntInsnNode)node).operand;
 		if(node instanceof LdcInsnNode)
 		{

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/Utils.java
@@ -59,6 +59,13 @@ public class Utils {
         return next;
     }
 
+    public static AbstractInsnNode getNext(AbstractInsnNode node, int amount) {
+        for (int i = 0; i < amount; i++) {
+            node = getNext(node);
+        }
+        return node;
+    }
+    
     public static AbstractInsnNode getNext(AbstractInsnNode node) {
         AbstractInsnNode next = node.getNext();
         while (!Utils.isInstruction(next)) {
@@ -369,10 +376,8 @@ public class Utils {
 		if(node.getOpcode() >= Opcodes.ICONST_M1
 			&& node.getOpcode() <= Opcodes.ICONST_5)
 			return node.getOpcode() - 3;
-		if (node.getOpcode() == Opcodes.BIPUSH) {
-		    return ((IntInsnNode) node).operand & 0xFF;
-        }
-		if(node.getOpcode() == Opcodes.SIPUSH)
+		if(node.getOpcode() == Opcodes.SIPUSH
+			|| node.getOpcode() == Opcodes.BIPUSH)
 			return ((IntInsnNode)node).operand;
 		if(node instanceof LdcInsnNode)
 		{


### PR DESCRIPTION
I added an Allatori flow deobfuscator. Since Allatori's flow obfuscation got improved, the transformer will greatly improve the readability of the code.
The Stringer "fix" uses brute force to determine where the "new" opcode should be placed in constructor obfuscation.
FILES CHANGED (OTHER FILES MERGE IS NOT NEEDED):
ArgsAnalyzer.java - Update
JVMMethodProvider.java - Small bug fixed + more methods
allatori/StringEncryptionTransformer.java (OLD) - Fix detector
allatori/FlowObfuscationTransformer.java - Remove allatori flow obfuscator
allatori/LightFlowObfuscationTransformer - Remove allatori dead code
stringer/HideAccessObfuscationTransformer - "Fallback" method to place the new opcode + fixes
smoke/NumberObfuscationTransformer - Better int handling
peephole/ConstantFolder - Fix
Utils.java - Some fixes
JavaMethod.class - Fix getMethods() and getFields()