### PR TITLE
Deobfuscation failed.

### DIFF
--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/invokedynamic/Invokedynamic1Transformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/stringer/invokedynamic/Invokedynamic1Transformer.java
@@ -113,6 +113,11 @@ public class Invokedynamic1Transformer extends Transformer<TransformerConfig> im
                     String desc = java_lang_invoke_MethodType.asSignature(data.get(2), false);
                     MethodNode indyMethod = owner.findMethodNode(name, desc, true);
 
+                    if (indyMethod == null) {
+                        oops("couldn't find method {} {}{}", classNode.name, name, desc);
+                        continue;
+                    }
+
                     int opcode;
                     if (Modifier.isStatic(indyMethod.access)) {
                         opcode = INVOKESTATIC;


### PR DESCRIPTION
java.lang.OutOfMemoryError: Java heap space
        at com.javadeobfuscator.org.objectweb.asm.tree.MethodNode.getLabelNode(MethodNode.java:626)
        at com.javadeobfuscator.org.objectweb.asm.tree.MethodNode.visitJumpInsn(MethodNode.java:476)
        at com.javadeobfuscator.org.objectweb.asm.commons.JSRInlinerAdapter.visitJumpInsn(JSRInlinerAdapter.java:159)
        at com.javadeobfuscator.org.objectweb.asm.tree.JumpInsnNode.accept(JumpInsnNode.java:88)
        at com.javadeobfuscator.org.objectweb.asm.tree.InsnList.accept(InsnList.java:162)
        at com.javadeobfuscator.org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:817)
        at com.javadeobfuscator.deobfuscator.Deobfuscator.loadInput(Deobfuscator.java:196)
        at com.javadeobfuscator.deobfuscator.Deobfuscator.loadInput(Deobfuscator.java:173)
        at com.javadeobfuscator.deobfuscator.Deobfuscator.start(Deobfuscator.java:249)
        at com.javadeobfuscator.deobfuscator.DeobfuscatorMain.run(DeobfuscatorMain.java:120)
        at com.javadeobfuscator.deobfuscator.DeobfuscatorMain.run(DeobfuscatorMain.java:92)
        at com.javadeobfuscator.deobfuscator.DeobfuscatorMain.main(DeobfuscatorMain.java:50)