### PR TITLE
Add class-file support for ASM-crashing classes using CAFED00D

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>com.github.Col-E</groupId>
             <artifactId>CAFED00D</artifactId>
-            <version>1.2.2</version>
+            <version>1.3.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
             <id>java-deobfuscator-repository</id>
             <url>https://repo.samczsun.com/repository/java-deobfuscator</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -174,6 +178,12 @@
             <groupId>com.javadeobfuscator</groupId>
             <artifactId>javavm</artifactId>
             <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.Col-E</groupId>
+            <artifactId>CAFED00D</artifactId>
+            <version>1.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/javadeobfuscator/deobfuscator/Deobfuscator.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/Deobfuscator.java
@@ -439,7 +439,7 @@ public class Deobfuscator {
     }
 
     public ClassNode assureLoaded(String ref) {
-        ClassNode clazz = classpath.get(ref.replace('/', '.'));
+        ClassNode clazz = classpath.get(ref);
         if (clazz == null) {
             throw new NoClassInPathException(ref);
         }
@@ -447,7 +447,7 @@ public class Deobfuscator {
     }
 
     public ClassNode assureLoadedElseRemove(String referencer, String ref) {
-        ClassNode clazz = classpath.get(ref.replace('/', '.'));
+        ClassNode clazz = classpath.get(ref);
         if (clazz == null) {
             classes.remove(referencer);
             classpath.remove(referencer);


### PR DESCRIPTION
Resolves #726 

This adds a fallback step in the `ClassNode` parsing step. If a node cannot be parsed, the `byte[]` of the class is first filtered through [CAFED00D](https://github.com/Col-E/CAFED00D) which strips out the illegally crafted attributes that cause ASM to crash. 

These attributes abuse the fact that the JVM does not load attributes until they are necessary, so you can toss literal garbage into there so long as it is barely complaint with the specs. ASM must read all attributes to work and does not consider some possibilities of _"loose interpretation"_ of the spec and crashes. 

Since these attributes aren't used at runtime it's OK to yeet 'em

****

This also adds support for the directory exploit that most newer obfuscators employ. 