### PR TITLE
#645: Don't remove still used decryptor methods

### DIFF
--- a/src/main/java/com/javadeobfuscator/deobfuscator/rules/allatori/RuleStringDecryptor.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/rules/allatori/RuleStringDecryptor.java
@@ -54,8 +54,10 @@ public class RuleStringDecryptor implements Rule {
                     }
                     MethodInsnNode m = (MethodInsnNode) ain;
                     String strCl = m.owner;
-                    if ((!m.desc.equals("(Ljava/lang/Object;)Ljava/lang/String;") && !m.desc.equals("(Ljava/lang/String;)Ljava/lang/String;"))
-                        || !deobfuscator.getClasses().containsKey(strCl)) {
+                    if (!m.desc.equals("(Ljava/lang/Object;)Ljava/lang/String;") && !m.desc.equals("(Ljava/lang/String;)Ljava/lang/String;")) {
+                        continue;
+                    }
+                    if (!deobfuscator.getClasses().containsKey(strCl)) {
                         continue;
                     }
                     ClassNode innerClassNode = deobfuscator.getClasses().get(strCl);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/StringEncryptionTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/allatori/StringEncryptionTransformer.java
@@ -16,6 +16,13 @@
 
 package com.javadeobfuscator.deobfuscator.transformers.allatori;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
 import com.javadeobfuscator.deobfuscator.executor.Context;
 import com.javadeobfuscator.deobfuscator.executor.MethodExecutor;
@@ -25,22 +32,40 @@ import com.javadeobfuscator.deobfuscator.executor.defined.MappedMethodProvider;
 import com.javadeobfuscator.deobfuscator.executor.providers.ComparisonProvider;
 import com.javadeobfuscator.deobfuscator.executor.providers.DelegatingProvider;
 import com.javadeobfuscator.deobfuscator.executor.values.JavaValue;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.InstructionModifier;
+import com.javadeobfuscator.deobfuscator.utils.TransformerHelper;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
 import org.objectweb.asm.tree.analysis.Analyzer;
 import org.objectweb.asm.tree.analysis.AnalyzerException;
 import org.objectweb.asm.tree.analysis.Frame;
 import org.objectweb.asm.tree.analysis.SourceInterpreter;
 import org.objectweb.asm.tree.analysis.SourceValue;
 
-import com.javadeobfuscator.deobfuscator.transformers.Transformer;
-import com.javadeobfuscator.deobfuscator.utils.InstructionModifier;
-import com.javadeobfuscator.deobfuscator.utils.TransformerHelper;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+public class StringEncryptionTransformer extends Transformer<StringEncryptionTransformer.Config> {
 
-public class StringEncryptionTransformer extends Transformer<TransformerConfig> {
+    public static class Config extends TransformerConfig {
+        private boolean cleanup = true;
+
+        public Config() {
+            super(StringEncryptionTransformer.class);
+        }
+
+        public boolean isCleanup() {
+            return cleanup;
+        }
+
+        public void setCleanup(boolean cleanup) {
+            this.cleanup = cleanup;
+        }
+    }
 
     @Override
     public boolean transform() throws Throwable {
@@ -85,114 +110,174 @@ public class StringEncryptionTransformer extends Transformer<TransformerConfig> 
 
         System.out.println("[Allatori] [StringEncryptionTransformer] Starting");
 
-        for(ClassNode classNode : classes.values())
-            for(MethodNode method : classNode.methods)
-            {
-            	InstructionModifier modifier = new InstructionModifier();
+        for (ClassNode classNode : classes.values()) {
+            for (MethodNode method : classNode.methods) {
+                InstructionModifier modifier = new InstructionModifier();
                 Frame<SourceValue>[] frames;
-                try 
-                {
+                try {
                     frames = new Analyzer<>(new SourceInterpreter()).analyze(classNode.name, method);
-                }catch(AnalyzerException e) 
-                {
+                } catch (AnalyzerException e) {
                     oops("unexpected analyzer exception", e);
                     continue;
                 }
 
-                for(AbstractInsnNode ain : TransformerHelper.instructionIterator(method))
-                	if(ain.getOpcode() == Opcodes.INVOKESTATIC) 
-                	{
-                        MethodInsnNode m = (MethodInsnNode)ain;
-                        String strCl = m.owner;
-                        if(m.desc.equals("(Ljava/lang/Object;)Ljava/lang/String;")
-                        	|| m.desc.equals("(Ljava/lang/String;)Ljava/lang/String;")) 
-                        {
-                        	Frame<SourceValue> f = frames[method.instructions.indexOf(m)];
-                        	if(f.getStack(f.getStackSize() - 1).insns.size() != 1)
-                        		continue;
-							AbstractInsnNode ldc = f.getStack(f.getStackSize() - 1).insns.iterator().next();
-							if(ldc.getOpcode() != Opcodes.LDC || !(((LdcInsnNode)ldc).cst instanceof String))
-								continue;
-    						Context context = new Context(provider);
-                            context.push(classNode.name, method.name, getDeobfuscator().getConstantPool(classNode).getSize());
-    						if(classes.containsKey(strCl)) 
-    						{
-    							ClassNode innerClassNode = classes.get(strCl);
-    							MethodNode decrypterNode = innerClassNode.methods.stream().filter(mn -> mn.name.equals(m.name) 
-    								&& mn.desc.equals(m.desc)).findFirst().orElse(null);
-    							if(decrypterNode == null || decrypterNode.instructions.getFirst() == null)
-    								continue;
-    					        Map<Integer, AtomicInteger> insnCount = new HashMap<>();
-    					        Map<String, AtomicInteger> invokeCount = new HashMap<>();
-    					        for(AbstractInsnNode i = decrypterNode.instructions.getFirst(); i != null; i = i.getNext()) 
-    					        {
-    					        	int opcode = i.getOpcode();
-    					        	insnCount.putIfAbsent(opcode, new AtomicInteger(0));
-    					        	insnCount.get(opcode).getAndIncrement();
-    					            if(i instanceof MethodInsnNode)
-    					            {
-    					            	invokeCount.putIfAbsent(((MethodInsnNode)i).name, new AtomicInteger(0));
-    					            	invokeCount.get(((MethodInsnNode)i).name).getAndIncrement();
-    					            }
-    					        }
-    							if(decryptor.contains(decrypterNode) || isAllatoriMethod(insnCount, invokeCount))
-    							{
-    								patchMethod(invokeCount, decrypterNode);
-                                    try 
-                                    {
-                                        ((LdcInsnNode)ldc).cst = MethodExecutor.execute(innerClassNode, decrypterNode, 
-                                        	Collections.singletonList(JavaValue.valueOf(((LdcInsnNode)ldc).cst)), null, context);
-            							modifier.remove(m);
-                                        decryptor.add(decrypterNode);
-                                        count.getAndIncrement();
-                                    }catch(Throwable t) 
-                                    {
-                                        System.out.println("Error while decrypting Allatori string.");
-                                        System.out.println("Are you sure you're deobfuscating something obfuscated by Allatori?");
-                                        System.out.println(classNode.name + " " + method.name + method.desc + " " + m.owner + " " + m.name + m.desc);
-                                        t.printStackTrace(System.out);
-                                    }
-    							}
-    						}
+                for (AbstractInsnNode ain : TransformerHelper.instructionIterator(method)) {
+                    if (ain.getOpcode() != Opcodes.INVOKESTATIC) {
+                        continue;
+                    }
+                    MethodInsnNode m = (MethodInsnNode) ain;
+                    String targetClass = m.owner;
+                    if (!m.desc.equals("(Ljava/lang/Object;)Ljava/lang/String;") && !m.desc.equals("(Ljava/lang/String;)Ljava/lang/String;")) {
+                        continue;
+                    }
+                    Frame<SourceValue> f = frames[method.instructions.indexOf(m)];
+                    if (f.getStack(f.getStackSize() - 1).insns.size() != 1) {
+                        continue;
+                    }
+                    AbstractInsnNode insn = f.getStack(f.getStackSize() - 1).insns.iterator().next();
+                    if (insn.getOpcode() != Opcodes.LDC) {
+                        continue;
+                    }
+                    LdcInsnNode ldc = (LdcInsnNode) insn;
+                    if (!(ldc.cst instanceof String)) {
+                        continue;
+                    }
+
+                    Context context = new Context(provider);
+                    context.push(classNode.name, method.name, getDeobfuscator().getConstantPool(classNode).getSize());
+
+                    ClassNode targetClassNode = classes.get(targetClass);
+                    if (targetClassNode == null) {
+                        continue;
+                    }
+
+                    MethodNode decrypterNode = targetClassNode.methods.stream()
+                            .filter(mn -> mn.name.equals(m.name) && mn.desc.equals(m.desc))
+                            .findFirst().orElse(null);
+                    if (decrypterNode == null || decrypterNode.instructions.getFirst() == null) {
+                        continue;
+                    }
+
+                    if (decryptor.contains(decrypterNode) || isAllatoriMethod(decrypterNode)) {
+                        patchMethod(decrypterNode);
+                        try {
+                            ldc.cst = MethodExecutor.execute(targetClassNode, decrypterNode,
+                                    Collections.singletonList(JavaValue.valueOf(ldc.cst)), null, context);
+                            modifier.remove(m);
+                            decryptor.add(decrypterNode);
+                            count.getAndIncrement();
+                        } catch (Throwable t) {
+                            System.out.println("Error while decrypting Allatori string.");
+                            System.out.println("Are you sure you're deobfuscating something obfuscated by Allatori?");
+                            System.out.println(classNode.name + " " + method.name + method.desc + " " + m.owner + " " + m.name + m.desc);
+                            t.printStackTrace(System.out);
                         }
-                	}
+                    }
+                }
                 modifier.apply(method);
             }
+        }
         System.out.println("[Allatori] [StringEncryptionTransformer] Decrypted " + count + " encrypted strings");
-        System.out.println("[Allatori] [StringEncryptionTransformer] Removed " + cleanup(decryptor) + " decryption methods");
+        if (getConfig().isCleanup()) {
+            System.out.println("[Allatori] [StringEncryptionTransformer] Removed " + cleanup(decryptor) + " decryption methods");
+        }
         System.out.println("[Allatori] [StringEncryptionTransformer] Done");
         return count.get() > 0;
     }
 
-    private boolean isAllatoriMethod(Map<Integer, AtomicInteger> insnCount, Map<String, AtomicInteger> invokeCount) {
-        //XXX: Better detector
-    	if(insnCount.get(Opcodes.IXOR) == null ||
-    		insnCount.get(Opcodes.NEWARRAY) == null ||
-    		invokeCount.get("charAt") == null || invokeCount.get("length") == null)
-    			return false;
-        return insnCount.get(Opcodes.IXOR).get() >= 3 &&
-               insnCount.get(Opcodes.NEWARRAY).get() >= 1 &&
-               invokeCount.get("charAt").get() >= 2 &&
-               invokeCount.get("length").get() >= 1;
+    public static boolean isAllatoriMethod(MethodNode decryptorNode) {
+        return isAllatoriMethod1(decryptorNode) || isAllatoriMethod2(decryptorNode);
     }
 
-    private void patchMethod(Map<String, AtomicInteger> invokeCount, MethodNode method) {
-        if (invokeCount.containsKey("getStackTrace") && invokeCount.containsKey("getClassName")) {
-            for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
-                if (insn.getOpcode() == Opcodes.NEW && (((TypeInsnNode) insn).desc.endsWith("Exception") || ((TypeInsnNode) insn).desc.endsWith("Error"))) {
-                    ((TypeInsnNode) insn).desc = "java/lang/RuntimeException";
-                } else if (insn instanceof MethodInsnNode && (((MethodInsnNode) insn).owner.endsWith("Exception") || ((MethodInsnNode) insn).owner.endsWith("Error"))) {
-                    ((MethodInsnNode) insn).owner = "java/lang/RuntimeException";
+    private static boolean isAllatoriMethod1(MethodNode decryptorNode) {
+        boolean isAllatori = true;
+        isAllatori = isAllatori && TransformerHelper.containsInvokeVirtual(decryptorNode, "java/lang/String", "charAt", "(I)C");
+        isAllatori = isAllatori && TransformerHelper.containsInvokeVirtual(decryptorNode, "java/lang/String", "length", "()I");
+        isAllatori = isAllatori && TransformerHelper.containsInvokeSpecial(decryptorNode, "java/lang/String", "<init>", null);
+        isAllatori = isAllatori && TransformerHelper.countOccurencesOf(decryptorNode, IXOR) > 2;
+        isAllatori = isAllatori && TransformerHelper.countOccurencesOf(decryptorNode, NEWARRAY) > 0;
+        return isAllatori;
+    }
+
+    private static boolean isAllatoriMethod2(MethodNode decryptorNode) {
+        Map<Integer, AtomicInteger> map = TransformerHelper.calcOpcodeOccurenceMap(decryptorNode);
+        AtomicInteger zero = new AtomicInteger();
+        boolean isAllatori = true;
+        isAllatori = isAllatori && map.getOrDefault(CASTORE, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(NEW, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(IINC, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(IXOR, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(I2C, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(ARETURN, zero).get() > 0;
+        isAllatori = isAllatori && map.getOrDefault(NEWARRAY, zero).get() == 1;
+        isAllatori = isAllatori && TransformerHelper.containsInvokeVirtual(decryptorNode, "java/lang/String", "charAt", "(I)C");
+        isAllatori = isAllatori && TransformerHelper.containsInvokeVirtual(decryptorNode, "java/lang/String", "length", "()I");
+        isAllatori = isAllatori && TransformerHelper.containsInvokeSpecial(decryptorNode, "java/lang/String", "<init>", null);
+        return isAllatori;
+    }
+
+    private void patchMethod(MethodNode method) {
+        boolean getStackTrace = false;
+        boolean getClassName = false;
+        for (AbstractInsnNode i = method.instructions.getFirst(); i != null; i = i.getNext()) {
+            if (!(i instanceof MethodInsnNode)) {
+                continue;
+            }
+            String name = ((MethodInsnNode) i).name;
+            if (!getStackTrace && name.equals("getStackTrace")) {
+                getStackTrace = true;
+                if (getClassName) {
+                    break;
+                }
+            } else if (!getClassName && name.equals("getClassName")) {
+                getClassName = true;
+                if (getStackTrace) {
+                    break;
+                }
+            }
+        }
+        if (!getClassName || !getStackTrace) {
+            return;
+        }
+        for (AbstractInsnNode insn = method.instructions.getFirst(); insn != null; insn = insn.getNext()) {
+            if (insn.getOpcode() == Opcodes.NEW) {
+                TypeInsnNode typeInsn = (TypeInsnNode) insn;
+                if (typeInsn.desc.endsWith("Exception") || typeInsn.desc.endsWith("Error")) {
+                    typeInsn.desc = "java/lang/RuntimeException";
+                }
+            } else if (insn instanceof MethodInsnNode) {
+                MethodInsnNode methodInsn = (MethodInsnNode) insn;
+                if (methodInsn.owner.endsWith("Exception") || methodInsn.owner.endsWith("Error")) {
+                    methodInsn.owner = "java/lang/RuntimeException";
                 }
             }
         }
     }
 
-    private int cleanup(Set<MethodNode> methods) {
+    private int cleanup(Set<MethodNode> toRemove) {
+        //remove methods from removal set which are still called
+        classNodes().forEach(node -> node.methods.forEach(methodNode -> {
+            for (AbstractInsnNode insn : methodNode.instructions) {
+                if (insn.getOpcode() != INVOKESTATIC) {
+                    continue;
+                }
+                MethodInsnNode m = (MethodInsnNode) insn;
+                ClassNode owner = classes.get(m.owner);
+                if (owner == null) {
+                    continue;
+                }
+                MethodNode mNode = owner.methods.stream().filter(mn -> mn.name.equals(m.name) && mn.desc.equals(m.desc)).findFirst().orElse(null);
+                toRemove.remove(mNode);
+            }
+        }));
         AtomicInteger count = new AtomicInteger(0);
         classNodes().forEach(classNode -> {
-            if (classNode.methods.removeIf(methods::contains)) {
-                count.getAndIncrement();
+            for (Iterator<MethodNode> it = classNode.methods.iterator(); it.hasNext(); ) {
+                MethodNode methodNode = it.next();
+                if (toRemove.remove(methodNode)) {
+                    it.remove();
+                    count.getAndIncrement();
+                }
             }
         });
         return count.get();

--- a/src/main/java/com/javadeobfuscator/deobfuscator/utils/TransformerHelper.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/utils/TransformerHelper.java
@@ -231,10 +231,9 @@ public class TransformerHelper implements Opcodes {
 
     public static Map<Integer, AtomicInteger> calcOpcodeOccurenceMap(MethodNode methodNode) {
         Map<Integer, AtomicInteger> map = new HashMap<>();
-        for (AbstractInsnNode abstractInsnNode : methodNode.instructions) {
-            int opcode = abstractInsnNode.getOpcode();
-            if (opcode >= 0) {
-                map.compute(opcode, (opc, i) -> {
+        for (AbstractInsnNode ain : methodNode.instructions) {
+            if (Utils.isInstruction(ain)) {
+                map.compute(ain.getOpcode(), (opc, i) -> {
                     if (i == null) {
                         return new AtomicInteger(1);
                     }


### PR DESCRIPTION
Fixes #645 

Improve allatori string decryption by not removing methods which are still called.

Fixes method removal count as well.

Also some general code style and minor speed improvements.