### PR TITLE
StackOperationSimplifier and misc

### DIFF
--- a/src/main/java/com/javadeobfuscator/deobfuscator/iterablematcher/IterableInsnMatcher.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/iterablematcher/IterableInsnMatcher.java
@@ -114,6 +114,8 @@ public class IterableInsnMatcher {
     }
 
     /**
+     * perform previously set up replacement / removal
+     * 
      * iterator afterwards will be just after the last matched step
      *
      * @param iterator must be in same state as it was after match was called

--- a/src/main/java/com/javadeobfuscator/deobfuscator/rules/special/RuleSuperblaubeereObfuscation.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/rules/special/RuleSuperblaubeereObfuscation.java
@@ -20,8 +20,7 @@ public class RuleSuperblaubeereObfuscation implements Rule {
 
 	@Override
 	public String getDescription() {
-		return "Superblaubeere obfuscator uses a variety of methods. It can obfuscate numbers, add redundant ifs, encrypt strings, pool numbers & strings into an" +
-			   " " +
+		return "Superblaubeere obfuscator uses a variety of methods. It can obfuscate numbers, add redundant ifs, encrypt strings, pool numbers & strings into an " +
 			   "array per class and obfuscate method calls with invokedynamic instructions.";
 	}
 

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/ByteArrayStringTransformer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/ByteArrayStringTransformer.java
@@ -19,6 +19,7 @@ import com.javadeobfuscator.deobfuscator.analyzer.frame.MethodFrame;
 import com.javadeobfuscator.deobfuscator.analyzer.frame.NewArrayFrame;
 import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
 import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.TransformerHelper;
 import com.javadeobfuscator.deobfuscator.utils.Utils;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnNode;
@@ -49,18 +50,11 @@ public class ByteArrayStringTransformer extends Transformer<TransformerConfig> {
                         }
 
                         MethodInsnNode min = (MethodInsnNode) ain;
-                        if (min.getOpcode() != INVOKESPECIAL) {
+
+                        if (!TransformerHelper.isInvokeSpecial(min,"java/lang/String", "<init>", "([B)V")) {
                             continue;
                         }
-                        if (!min.owner.equals("java/lang/String")) {
-                            continue;
-                        }
-                        if (!min.name.equals("<init>")) {
-                            continue;
-                        }
-                        if (!min.desc.equals("([B)V")) {
-                            continue;
-                        }
+
                         if (result == null) {
                             result = MethodAnalyzer.analyze(classNode, methodNode);
                         }

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/NopRemover.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/NopRemover.java
@@ -1,0 +1,31 @@
+package com.javadeobfuscator.deobfuscator.transformers.general.peephole;
+
+import java.util.ListIterator;
+import java.util.concurrent.atomic.LongAdder;
+
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import org.objectweb.asm.tree.AbstractInsnNode;
+
+public class NopRemover extends Transformer<TransformerConfig> {
+    
+    @Override
+    public boolean transform() throws Throwable {
+        LongAdder counter = new LongAdder();
+        classNodes().forEach(classNode -> classNode.methods.stream().filter(methodNode -> methodNode.instructions.getFirst() != null).forEach(methodNode -> {
+            ListIterator<AbstractInsnNode> it = methodNode.instructions.iterator();
+            while (it.hasNext()) {
+                AbstractInsnNode node = it.next();
+                if (node.getOpcode() == NOP) {
+                    it.remove();
+                    counter.increment();
+                }
+            }
+        }));
+        if (counter.sum() > 0) {
+            System.out.println("Removed " + counter + " nops");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/PeepholeOptimizer.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/PeepholeOptimizer.java
@@ -44,6 +44,7 @@ public class PeepholeOptimizer extends Transformer<TransformerConfig> {
     }
 
     static {
+        PEEPHOLE_TRANSFORMERS.add(NopRemover.class);
         PEEPHOLE_TRANSFORMERS.add(RedundantTrapRemover.class);
 //        PEEPHOLE_TRANSFORMERS.add(TrapHandlerMerger.class); // still experimental
         PEEPHOLE_TRANSFORMERS.add(GotoRearranger.class);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/StackOperationSimplifier.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/StackOperationSimplifier.java
@@ -30,7 +30,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             SimpleStep step1 = new SimpleStep(POP);
             SimpleStep step2 = new SimpleStep(POP);
-            operations.add(new Tuple3<>("Simplified %1$ POP-POP to POP2", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s POP-POP to POP2", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
             }), m -> {
@@ -43,7 +43,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(false);
             SimpleStep step2 = new SimpleStep(DUP);
-            operations.add(new Tuple3<>("Simplified %1$ LDC1-DUP to LDC1-LDC1", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s LDC1-DUP to LDC1-LDC1", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
             }), m -> {
@@ -55,7 +55,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad2SlotStep step1 = new NoSideEffectLoad2SlotStep(false);
             SimpleStep step2 = new SimpleStep(DUP2);
-            operations.add(new Tuple3<>("Simplified %1$ LDC2-DUP2 to LDC2-LDC2", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s LDC2-DUP2 to LDC2-LDC2", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
             }), m -> {
@@ -65,7 +65,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // INEG - INEG => nothing
         {
-            operations.add(new Tuple3<>("Removed %1$ double INEG", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Removed %1$s double INEG", new IterableInsnMatcher(m -> {
                 m.addStep(new SimpleStep(INEG));
                 m.addStep(new SimpleStep(INEG));
             }), m -> {
@@ -75,7 +75,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // LNEG - LNEG => nothing
         {
-            operations.add(new Tuple3<>("Removed %1$ double LNEG", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Removed %1$s double LNEG", new IterableInsnMatcher(m -> {
                 m.addStep(new SimpleStep(LNEG));
                 m.addStep(new SimpleStep(LNEG));
             }), m -> {
@@ -85,7 +85,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // DUP - POP2 => POP
         {
-            operations.add(new Tuple3<>("Simplified %1$ DUP-POP2 to POP", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s DUP-POP2 to POP", new IterableInsnMatcher(m -> {
                 m.addStep(new SimpleStep(DUP));
                 m.addStep(new SimpleStep(POP2));
             }), m -> {
@@ -96,7 +96,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // LDC1 - POP => nothing
         {
-            operations.add(new Tuple3<>("Removed %1$ LDC1-POP", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Removed %1$s LDC1-POP", new IterableInsnMatcher(m -> {
                 m.addStep(new NoSideEffectLoad1SlotStep(true));
                 m.addStep(new SimpleStep(POP));
             }), m -> {
@@ -106,7 +106,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // LDC1 - LDC1 - POP2 => nothing
         {
-            operations.add(new Tuple3<>("Removed %1$ LDC1-LDC1-POP2", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Removed %1$s LDC1-LDC1-POP2", new IterableInsnMatcher(m -> {
                 m.addStep(new NoSideEffectLoad1SlotStep(true));
                 m.addStep(new NoSideEffectLoad1SlotStep(true));
                 m.addStep(new SimpleStep(POP2));
@@ -117,7 +117,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         }
         // LDC2 - POP2 => nothing
         {
-            operations.add(new Tuple3<>("Removed %1$ LDC2-POP2", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Removed %1$s LDC2-POP2", new IterableInsnMatcher(m -> {
                 m.addStep(new NoSideEffectLoad2SlotStep(true));
                 m.addStep(new SimpleStep(POP2));
             }), m -> {
@@ -129,7 +129,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
             SimpleStep step2 = new SimpleStep(POP2);
-            operations.add(new Tuple3<>("Simplified %1$ LDC1-POP2 to POP", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s LDC1-POP2 to POP", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
             }), m -> {
@@ -142,10 +142,10 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad2SlotStep step1 = new NoSideEffectLoad2SlotStep(true);
             NoSideEffectLoad2SlotStep step2 = new NoSideEffectLoad2SlotStep(true);
-            SimpleStep step3 = new SimpleStep(Opcodes.DUP2_X2);
-            SimpleStep step4 = new SimpleStep(Opcodes.POP2);
-            SimpleStep step5 = new SimpleStep(Opcodes.POP2);
-            operations.add(new Tuple3<>("Simplified %1$ LDC2-LDC2-DUP2_X2-POP2-POP2 to LDC2 (2nd LDC)", new IterableInsnMatcher(m -> {
+            SimpleStep step3 = new SimpleStep(DUP2_X2);
+            SimpleStep step4 = new SimpleStep(POP2);
+            SimpleStep step5 = new SimpleStep(POP2);
+            operations.add(new Tuple3<>("Simplified %1$s LDC2-LDC2-DUP2_X2-POP2-POP2 to LDC2 (2nd LDC)", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
                 m.addStep(step3);
@@ -164,9 +164,9 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
             NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
-            SimpleStep step3 = new SimpleStep(Opcodes.DUP_X1);
-            SimpleStep step4 = new SimpleStep(Opcodes.POP);
-            operations.add(new Tuple3<>("Simplified %1$ LDC1-LDC1-DUP_X1-POP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
+            SimpleStep step3 = new SimpleStep(DUP_X1);
+            SimpleStep step4 = new SimpleStep(POP);
+            operations.add(new Tuple3<>("Simplified %1$s LDC1-LDC1-DUP_X1-POP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
                 m.addStep(step3);
@@ -183,12 +183,12 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
             NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
-            SimpleStep step3 = new SimpleStep(Opcodes.SWAP);
-            SimpleStep step4 = new SimpleStep(Opcodes.DUP_X1);
-            SimpleStep step5 = new SimpleStep(Opcodes.POP2);
+            SimpleStep step3 = new SimpleStep(SWAP);
+            SimpleStep step4 = new SimpleStep(DUP_X1);
+            SimpleStep step5 = new SimpleStep(POP2);
             NoSideEffectLoad1SlotStep step6 = new NoSideEffectLoad1SlotStep(true);
-            SimpleStep step7 = new SimpleStep(Opcodes.POP2);
-            operations.add(new Tuple3<>("Removed %1$ LDC1-LDC1-SWAP-DUP_X1-POP2-LDC1-POP2", new IterableInsnMatcher(m -> {
+            SimpleStep step7 = new SimpleStep(POP2);
+            operations.add(new Tuple3<>("Removed %1$s LDC1-LDC1-SWAP-DUP_X1-POP2-LDC1-POP2", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
                 m.addStep(step3);
@@ -205,12 +205,15 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
         {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
             NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
-            operations.add(new Tuple3<>("Simplified %1$ LDC1-LDC1-SWAP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
+            SimpleStep step3 = new SimpleStep(SWAP);
+            operations.add(new Tuple3<>("Simplified %1$s LDC1-LDC1-SWAP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
+                m.addStep(step3);
             }), m -> {
                 m.addReplacement(step1, step2.getCaptured().clone(null));
                 m.addReplacement(step2, step1.getCaptured().clone(null));
+                m.addRemoval(step3);
                 return true;
             }));
         }
@@ -219,7 +222,7 @@ public class StackOperationSimplifier extends Transformer<TransformerConfig> {
             NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
             SimpleStep step2 = new SimpleStep(SWAP);
             SimpleStep step3 = new SimpleStep(POP);
-            operations.add(new Tuple3<>("Simplified %1$ LDC1-SWAP-POP to POP-LDC1", new IterableInsnMatcher(m -> {
+            operations.add(new Tuple3<>("Simplified %1$s LDC1-SWAP-POP to POP-LDC1", new IterableInsnMatcher(m -> {
                 m.addStep(step1);
                 m.addStep(step2);
                 m.addStep(step3);

--- a/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/StackOperationSimplifier.java
+++ b/src/main/java/com/javadeobfuscator/deobfuscator/transformers/general/peephole/StackOperationSimplifier.java
@@ -1,0 +1,272 @@
+package com.javadeobfuscator.deobfuscator.transformers.general.peephole;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Predicate;
+
+import com.javadeobfuscator.deobfuscator.config.TransformerConfig;
+import com.javadeobfuscator.deobfuscator.iterablematcher.IterableInsnMatcher;
+import com.javadeobfuscator.deobfuscator.iterablematcher.NoSideEffectLoad1SlotStep;
+import com.javadeobfuscator.deobfuscator.iterablematcher.NoSideEffectLoad2SlotStep;
+import com.javadeobfuscator.deobfuscator.iterablematcher.SimpleStep;
+import com.javadeobfuscator.deobfuscator.transformers.Transformer;
+import com.javadeobfuscator.deobfuscator.utils.Utils;
+import org.jooq.lambda.tuple.Tuple3;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+
+public class StackOperationSimplifier extends Transformer<TransformerConfig> {
+
+    private final List<Tuple3<String, IterableInsnMatcher, Predicate<IterableInsnMatcher>>> operations = new ArrayList<>();
+
+    {
+        // POP - POP => POP2
+        {
+            SimpleStep step1 = new SimpleStep(POP);
+            SimpleStep step2 = new SimpleStep(POP);
+            operations.add(new Tuple3<>("Simplified %1$ POP-POP to POP2", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+            }), m -> {
+                m.addRemoval(step1);
+                m.addReplacement(step2, new InsnNode(POP2));
+                return true;
+            }));
+        }
+        // LDC1 - DUP => LDC LDC
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(false);
+            SimpleStep step2 = new SimpleStep(DUP);
+            operations.add(new Tuple3<>("Simplified %1$ LDC1-DUP to LDC1-LDC1", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+            }), m -> {
+                m.addReplacement(step2, step1.getCaptured().clone(null));
+                return true;
+            }));
+        }
+        // LDC2 - DUP2 => LDC2 LDC2
+        {
+            NoSideEffectLoad2SlotStep step1 = new NoSideEffectLoad2SlotStep(false);
+            SimpleStep step2 = new SimpleStep(DUP2);
+            operations.add(new Tuple3<>("Simplified %1$ LDC2-DUP2 to LDC2-LDC2", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+            }), m -> {
+                m.addReplacement(step2, step1.getCaptured().clone(null));
+                return true;
+            }));
+        }
+        // INEG - INEG => nothing
+        {
+            operations.add(new Tuple3<>("Removed %1$ double INEG", new IterableInsnMatcher(m -> {
+                m.addStep(new SimpleStep(INEG));
+                m.addStep(new SimpleStep(INEG));
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // LNEG - LNEG => nothing
+        {
+            operations.add(new Tuple3<>("Removed %1$ double LNEG", new IterableInsnMatcher(m -> {
+                m.addStep(new SimpleStep(LNEG));
+                m.addStep(new SimpleStep(LNEG));
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // DUP - POP2 => POP
+        {
+            operations.add(new Tuple3<>("Simplified %1$ DUP-POP2 to POP", new IterableInsnMatcher(m -> {
+                m.addStep(new SimpleStep(DUP));
+                m.addStep(new SimpleStep(POP2));
+            }), m -> {
+                m.setRemoval(0);
+                m.setReplacement(1, new InsnNode(POP));
+                return true;
+            }));
+        }
+        // LDC1 - POP => nothing
+        {
+            operations.add(new Tuple3<>("Removed %1$ LDC1-POP", new IterableInsnMatcher(m -> {
+                m.addStep(new NoSideEffectLoad1SlotStep(true));
+                m.addStep(new SimpleStep(POP));
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // LDC1 - LDC1 - POP2 => nothing
+        {
+            operations.add(new Tuple3<>("Removed %1$ LDC1-LDC1-POP2", new IterableInsnMatcher(m -> {
+                m.addStep(new NoSideEffectLoad1SlotStep(true));
+                m.addStep(new NoSideEffectLoad1SlotStep(true));
+                m.addStep(new SimpleStep(POP2));
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // LDC2 - POP2 => nothing
+        {
+            operations.add(new Tuple3<>("Removed %1$ LDC2-POP2", new IterableInsnMatcher(m -> {
+                m.addStep(new NoSideEffectLoad2SlotStep(true));
+                m.addStep(new SimpleStep(POP2));
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // LDC1 - POP2 => POP
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
+            SimpleStep step2 = new SimpleStep(POP2);
+            operations.add(new Tuple3<>("Simplified %1$ LDC1-POP2 to POP", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+            }), m -> {
+                m.addRemoval(step1);
+                m.addReplacement(step2, new InsnNode(POP));
+                return true;
+            }));
+        }
+        // LDC2 - LDC2 - DUP2_X2 - POP2 - POP2 => LDC2 (the second ldc2)
+        {
+            NoSideEffectLoad2SlotStep step1 = new NoSideEffectLoad2SlotStep(true);
+            NoSideEffectLoad2SlotStep step2 = new NoSideEffectLoad2SlotStep(true);
+            SimpleStep step3 = new SimpleStep(Opcodes.DUP2_X2);
+            SimpleStep step4 = new SimpleStep(Opcodes.POP2);
+            SimpleStep step5 = new SimpleStep(Opcodes.POP2);
+            operations.add(new Tuple3<>("Simplified %1$ LDC2-LDC2-DUP2_X2-POP2-POP2 to LDC2 (2nd LDC)", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+                m.addStep(step3);
+                m.addStep(step4);
+                m.addStep(step5);
+            }), m -> {
+                m.addRemoval(step1);
+                // the second ldc (step2) stays
+                m.addRemoval(step3);
+                m.addRemoval(step4);
+                m.addRemoval(step5);
+                return true;
+            }));
+        }
+        // LDC1 - LDC1 - DUP_X1 - POP => LDC1 - LDC1 (LDC's swapped)
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
+            NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
+            SimpleStep step3 = new SimpleStep(Opcodes.DUP_X1);
+            SimpleStep step4 = new SimpleStep(Opcodes.POP);
+            operations.add(new Tuple3<>("Simplified %1$ LDC1-LDC1-DUP_X1-POP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+                m.addStep(step3);
+                m.addStep(step4);
+            }), m -> {
+                m.addRemoval(step1);
+                m.addRemoval(step2);
+                m.addReplacement(step3, step2.getCaptured());
+                m.addReplacement(step4, step1.getCaptured());
+                return true;
+            }));
+        }
+        // LDC1 - LDC1 - SWAP - DUP_X1 - POP2 - LDC1 - POP2 => nothing
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
+            NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
+            SimpleStep step3 = new SimpleStep(Opcodes.SWAP);
+            SimpleStep step4 = new SimpleStep(Opcodes.DUP_X1);
+            SimpleStep step5 = new SimpleStep(Opcodes.POP2);
+            NoSideEffectLoad1SlotStep step6 = new NoSideEffectLoad1SlotStep(true);
+            SimpleStep step7 = new SimpleStep(Opcodes.POP2);
+            operations.add(new Tuple3<>("Removed %1$ LDC1-LDC1-SWAP-DUP_X1-POP2-LDC1-POP2", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+                m.addStep(step3);
+                m.addStep(step4);
+                m.addStep(step5);
+                m.addStep(step6);
+                m.addStep(step7);
+            }), m -> {
+                m.setRemoveAll();
+                return true;
+            }));
+        }
+        // LDC1 - LDC1 - SWAP => LDC1 - LDC1 (LDC's swapped)
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
+            NoSideEffectLoad1SlotStep step2 = new NoSideEffectLoad1SlotStep(true);
+            operations.add(new Tuple3<>("Simplified %1$ LDC1-LDC1-SWAP to LDC1-LDC1 (swapped)", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+            }), m -> {
+                m.addReplacement(step1, step2.getCaptured().clone(null));
+                m.addReplacement(step2, step1.getCaptured().clone(null));
+                return true;
+            }));
+        }
+        // LDC1 - SWAP - POP => POP - LDC1
+        {
+            NoSideEffectLoad1SlotStep step1 = new NoSideEffectLoad1SlotStep(true);
+            SimpleStep step2 = new SimpleStep(SWAP);
+            SimpleStep step3 = new SimpleStep(POP);
+            operations.add(new Tuple3<>("Simplified %1$ LDC1-SWAP-POP to POP-LDC1", new IterableInsnMatcher(m -> {
+                m.addStep(step1);
+                m.addStep(step2);
+                m.addStep(step3);
+            }), m -> {
+                m.addReplacement(step1, new InsnNode(POP));
+                m.addReplacement(step2, step1.getCaptured().clone(null));
+                m.addRemoval(step3);
+                return true;
+            }));
+        }
+    }
+
+    @Override
+    public boolean transform() throws Throwable {
+        Map<Tuple3<String, IterableInsnMatcher, Predicate<IterableInsnMatcher>>, LongAdder> counters = new HashMap<>();
+        AtomicBoolean changed = new AtomicBoolean(false);
+        classNodes().forEach(classNode -> classNode.methods.stream().filter(Utils::notAbstractOrNative).forEach(methodNode -> {
+            boolean edit = false;
+            do {
+                if (edit) {
+                    changed.set(true);
+                }
+                edit = false;
+                ListIterator<AbstractInsnNode> iterator = methodNode.instructions.iterator();
+                for (Tuple3<String, IterableInsnMatcher, Predicate<IterableInsnMatcher>> key : operations) {
+                    IterableInsnMatcher matcher = key.v2;
+                    if (!matcher.match(iterator)) {
+                        continue;
+                    }
+                    // match successful, apply matcher-specific logic
+                    // matcher-specific logic can stop replacement in case additional constraints were not met
+                    if (!key.v3.test(matcher)) {
+                        matcher.reset();
+                        continue;
+                    }
+                    matcher.replace(iterator);
+                    matcher.reset();
+                    edit = true;
+                    counters.computeIfAbsent(key, (key_) -> new LongAdder()).increment();
+                }
+            } while (edit);
+        }));
+        counters.forEach((entry, counter) -> {
+            System.out.printf(entry.v1, counter.sum());
+            System.out.println();
+        });
+        //TODO output
+        return changed.get();
+    }
+}


### PR DESCRIPTION
`StackOperationSimplifier`'s patterns are some of my private fork, some of these might've also been present already in an earlier version of this deobfuscator.
~~As I created those before I created the IterableInsnMatcher, I recoded them with that helper. It is possible that I did not extract all patterns correctly from the old code or that other bugs are present.
I will do some testing of the StackOperationSimplifier later on vs. some random obfuscation samples with asm's verifier to make sure there are no huge hikkups present.~~ Not anymore. Tested.

Other changes:
- Add `NopRemover`
- code style / javadoc