### PR TITLE
fix(sec): upgrade jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.1</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrade jackson-databind from 2.9.1 to 2.12.6.1 for vulnerability fix:
- [CVE-2017-17485](https://www.oscs1024.com/hd/MPS-2018-0362)
- [CVE-2018-5968](https://www.oscs1024.com/hd/MPS-2018-0934)
- [CVE-2018-7489](https://www.oscs1024.com/hd/MPS-2018-2477)